### PR TITLE
Remove callback from Redis.connect()

### DIFF
--- a/Sources/Redis.swift
+++ b/Sources/Redis.swift
@@ -46,15 +46,11 @@ public class Redis {
     /// - Parameter port: port number
     /// - Parameter callback: callback function for on completion
     ///
-    public func connect (host: String, port: Int32, callback: (NSError?) -> Void) {
-
-        var error: NSError? = nil
-
-        respHandle = RedisResp(host: host, port: port)
-        if  respHandle!.status != .connected {
-            error = createError("Failed to connect to Redis server", code: 2)
+    public func connect(host: String, port: Int32) throws {
+        respHandle =  RedisResp(host: host, port: port)
+        guard respHandle?.status == .connected else {
+            throw createError("Failed to connect to Redis server", code: 2)
         }
-        callback(error)
     }
 
     ///

--- a/Sources/RedisResp.swift
+++ b/Sources/RedisResp.swift
@@ -44,7 +44,7 @@ internal class RedisResp {
     internal init(host: String, port: Int32) {
         do {
             socket = try Socket.create()
-            try socket!.connect(to: host, port: port)
+            try socket?.connect(to: host, port: port)
             status = .connected
         }
         catch {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description

<!--- Describe your changes in detail -->

The `Redis.connect()` method currently accepts a completion handler with an optional `NSError` indicating the status of the connection.  This pull request removes the completion handler entirely, and instead allows the `connect()` method to `throw`.  It may now be used as such:

``` swift
try redis.connect(host: "127.0.0.1", port: 6379)
```
## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

<!--- If it fixes an open issue, please link to the issue here. -->

Requiring a completion handler suggests to the user that the `connect()` method is an asynchronous operation, which it is not.  In addition, the use of optional `NSError`s is reminiscent of Swift 1.x error handling and has generally been replaced by `throw`.
## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have submitted a [CLA form](https://github.com/IBM-Swift/CLA)
- [x] If applicable, I have updated the documentation accordingly.
- [x] If applicable, I have added tests to cover my changes.
