### PR TITLE
Crash in Linux setting an empty value

### DIFF
--- a/Sources/RedisResp.swift
+++ b/Sources/RedisResp.swift
@@ -61,7 +61,10 @@ internal class RedisResp {
         buffer.append(RedisResp.crLf)
 
         for arg in stringArgs {
-            addAsBulkString(StringUtils.toUtf8String(arg)!, to: buffer)
+            // NSString.data(encoding:) which is called by StringUtils.toUtf8String will return nil on Linux on an empty string
+            // eventually this needs to be changed in swift-corelibs-foundation
+            // the "?? NSData()" ensures that an empty NSData is added if the "arg" is empty
+            addAsBulkString(StringUtils.toUtf8String(arg) ?? NSData(), to: buffer)
         }
 
         do {

--- a/Tests/SwiftRedis/TestBasicCommands.swift
+++ b/Tests/SwiftRedis/TestBasicCommands.swift
@@ -33,7 +33,8 @@ public class TestBasicCommands: XCTestCase {
             ("test_SetExistOptions", test_SetExistOptions),
             ("test_SetExpireOptions", test_SetExpireOptions),
             ("test_incrDecr", test_incrDecr),
-            ("test_incrFloats", test_incrFloats)
+            ("test_incrFloats", test_incrFloats),
+            ("test_empty", test_empty)
         ]
     }
     
@@ -207,6 +208,22 @@ public class TestBasicCommands: XCTestCase {
                     XCTAssertNotNil(newValue, "Result of an INCRBYFLOAT shouldn't be nil")
                     XCTAssertEqual(theValue+Double(incValue), newValue!.asDouble, "The returned value wasn't \(theValue+Double(incValue))")
                     theValue = newValue!.asDouble
+                }
+            }
+        }
+    }
+
+    func test_empty() {
+        localSetup() {
+            let emptyValue = ""
+
+            redis.set(self.key1, value: emptyValue) {(wasSet: Bool, error: NSError?) in
+                XCTAssertNil(error, "\(error != nil ? error!.localizedDescription : "")")
+                XCTAssert(wasSet, "Failed to set \(self.key1)")
+
+                redis.get(self.key1) {(returnedValue: RedisString?, error: NSError?) in
+                    XCTAssertNil(error, "\(error != nil ? error!.localizedDescription : "")")
+                    XCTAssertEqual(returnedValue!.asString, emptyValue, "Returned value was not '\(emptyValue)'")
                 }
             }
         }


### PR DESCRIPTION
## Description

Fix for issue #13
## Motivation and Context

This is a workaround for a bug in swift-corelibs-foundation.
Currently, NSString.data(encoding:) will return nil on Linux on an empty string.
## How Has This Been Tested?

Unit tested on Mac and Linux
## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have submitted a [CLA form](https://github.com/IBM-Swift/CLA)
- [ ] If applicable, I have updated the documentation accordingly.
- [x] If applicable, I have added tests to cover my changes.
