### PR TITLE
Fixes for Issue 623

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 .build/
 Packages/
+/SwiftRedis.xcodeproj
+

--- a/Tests/SwiftRedis/TestConnectCommands.swift
+++ b/Tests/SwiftRedis/TestConnectCommands.swift
@@ -33,17 +33,19 @@ public class TestConnectCommands: XCTestCase {
             
             redis.ping() {(error: NSError?) in
                 XCTAssertNil(error, "\(error != nil ? error!.localizedDescription : "")")
+                
+                /* Changed for Redis 2.8.0
                 let pingText = "Hello, hello, hello, hi there"
                 redis.ping(pingText) {(error: NSError?) in
                     XCTAssertNil(error, "\(error != nil ? error!.localizedDescription : "")")
-                    
+                */
                     let echoText = "Echo, echo, echo......"
                     redis.echo(echoText) {(text: RedisString?, error: NSError?) in
                         XCTAssertNil(error, "\(error != nil ? error!.localizedDescription : "")")
                         XCTAssertNotNil(text, "Received a nil for echo text")
                         XCTAssertEqual(text!.asString, echoText, "Echo returned '\(text!)'. Should have returned '\(echoText)'.")
                     }
-                }
+               /* } */
             }
         }
     }

--- a/Tests/SwiftRedis/TestMoreCommands.swift
+++ b/Tests/SwiftRedis/TestMoreCommands.swift
@@ -84,7 +84,7 @@ public class TestMoreCommands: XCTestCase {
     
     func test_keyManipulation() {
         setupTests() {
-            redis.mset((self.key1, self.expVal1), (self.key2, self.expVal2)) {(werSet: Bool, error: NSError?) in
+            redis.mset((self.key1, self.expVal1), (self.key2, self.expVal2)) {(wereSet: Bool, error: NSError?) in
                 XCTAssertNil(error, "\(error != nil ? error!.localizedDescription : "")")
                 
                 redis.rename(self.key1, newKey: self.key3) {(renamed: Bool, error: NSError?) in
@@ -104,10 +104,16 @@ public class TestMoreCommands: XCTestCase {
                                 XCTAssertNil(error, "\(error != nil ? error!.localizedDescription : "")")
                                 XCTAssert(renamed, "Should have renamed \(self.key3) to \(self.key4)")
                                 
-                                redis.exists(self.key1, self.key2, self.key3, self.key4) {(count: Int?, error: NSError?) in
+                                redis.exists(self.key1) {(count: Int?, error: NSError?) in
                                     XCTAssertNil(error, "\(error != nil ? error!.localizedDescription : "")")
                                     XCTAssertNotNil(count, "Count of keys should not be nil")
-                                    XCTAssertEqual(count!, 2, "Only two keys are suppose to exist, reported \(count!)")
+                                    XCTAssertEqual(count!, 0, "\(self.key1) should not exist")
+                                    
+                                    redis.exists(self.key4) {(count: Int?, error: NSError?) in
+                                        XCTAssertNil(error, "\(error != nil ? error!.localizedDescription : "")")
+                                        XCTAssertNotNil(count, "Count of keys should not be nil")
+                                        XCTAssertEqual(count!, 1, "\(self.key4) should exist")
+                                    }
                                 }
                             }
                         }

--- a/Tests/SwiftRedis/TestStringAndBitCommands.swift
+++ b/Tests/SwiftRedis/TestStringAndBitCommands.swift
@@ -89,7 +89,9 @@ public class TestStringAndBitCommands: XCTestCase {
            
             redis.set(self.key1, value: RedisString(expVal1)) {(wasSet: Bool,  error: NSError?) in
                 XCTAssertNil(error, "\(error != nil ? error!.localizedDescription : "")")
-                    
+                
+                /* bitpos was added in redis 2.8.7 
+ 
                 redis.bitpos(self.key1, bit: true) {(position: Int?, error: NSError?) in
                     XCTAssertNil(error, "\(error != nil ? error!.localizedDescription : "")")
                     XCTAssertNotNil(position, "Position result shouldn't be nil")
@@ -104,7 +106,9 @@ public class TestStringAndBitCommands: XCTestCase {
                             XCTAssertNil(error, "\(error != nil ? error!.localizedDescription : "")")
                             XCTAssertNotNil(position, "Position result shouldn't be nil")
                             XCTAssertEqual(position!, 15, "Bit position should have been 15, was \(position)")
-                                
+ 
+                    */
+ 
                             redis.bitcount(self.key1) {(count: Int?, error: NSError?) in
                                 XCTAssertNil(error, "\(error != nil ? error!.localizedDescription : "")")
                                 XCTAssertNotNil(count, "Count result shouldn't be nil")
@@ -116,9 +120,9 @@ public class TestStringAndBitCommands: XCTestCase {
                                     XCTAssertEqual(count!, 1, "Bit count should have been 1, was \(count)")
                                 }
                             }
-                        }
+                     /*   }
                     }
-                }
+                } */
             }
         }
     }

--- a/Tests/SwiftRedis/TestTransactionsPart2.swift
+++ b/Tests/SwiftRedis/TestTransactionsPart2.swift
@@ -151,17 +151,21 @@ public class TestTransactionsPart2: XCTestCase {
 
             let multi = redis.multi()
             multi.set(self.key1, value: RedisString(expVal1))
+            multi.bitcount(self.key1).bitcount(self.key1, start: 2, end: 2)
+            /* Removed tests of bitpos - not in Redis 2.8.0
             multi.bitpos(self.key1, bit: true).bitpos(self.key1, bit: true, start: 2)
             multi.bitpos(self.key1, bit: true, start: 1, end: 2)
-            multi.bitcount(self.key1).bitcount(self.key1, start: 2, end: 2)
+            */
             multi.exec() {(response: RedisResponse) in
-                if  let nestedResponses = self.baseAsserts(response: response, count: 6)  {
+                if  let nestedResponses = self.baseAsserts(response: response, count: 3)  {
                     XCTAssertEqual(nestedResponses[0], RedisResponse.Status("OK"), "set didn't return an 'OK'")
-                    XCTAssertEqual(nestedResponses[1], RedisResponse.IntegerValue(15), "Bit position should have been 15, was \(nestedResponses[1].asInteger)")
-                    XCTAssertEqual(nestedResponses[2], RedisResponse.IntegerValue(23), "Bit position should have been 23, was \(nestedResponses[1].asInteger)")
-                    XCTAssertEqual(nestedResponses[3], RedisResponse.IntegerValue(15), "Bit position should have been 15, was \(nestedResponses[3].asInteger)")
-                    XCTAssertEqual(nestedResponses[4], RedisResponse.IntegerValue(2), "Bit count should have been 2, was \(nestedResponses[4].asInteger)")
-                    XCTAssertEqual(nestedResponses[5], RedisResponse.IntegerValue(1), "Bit count should have been 1, was \(nestedResponses[5].asInteger)")
+                    XCTAssertEqual(nestedResponses[1], RedisResponse.IntegerValue(2), "Bit count should have been 2, was \(nestedResponses[4].asInteger)")
+                    XCTAssertEqual(nestedResponses[2], RedisResponse.IntegerValue(1), "Bit count should have been 1, was \(nestedResponses[5].asInteger)")
+                    /* Removed tests of bitpos - not in Redis 2.8.0
+                    XCTAssertEqual(nestedResponses[3], RedisResponse.IntegerValue(15), "Bit position should have been 15, was \(nestedResponses[1].asInteger)")
+                    XCTAssertEqual(nestedResponses[4], RedisResponse.IntegerValue(23), "Bit position should have been 23, was \(nestedResponses[1].asInteger)")
+                    XCTAssertEqual(nestedResponses[5], RedisResponse.IntegerValue(15), "Bit position should have been 15, was \(nestedResponses[3].asInteger)")
+                    */
                 }
             }
         }

--- a/Tests/SwiftRedis/TestTransactionsPart3.swift
+++ b/Tests/SwiftRedis/TestTransactionsPart3.swift
@@ -47,16 +47,17 @@ public class TestTransactionsPart3: XCTestCase {
             multi.rename(self.key1, newKey: self.key3).get(self.key3)
             multi.rename(self.key3, newKey: self.key2, exists: false)
             multi.rename(self.key3, newKey: self.key4, exists: false)
-            multi.exists(self.key1, self.key2, self.key3, self.key4)
+            multi.exists(self.key1).exists(self.key4)
 
             multi.exec() {(response: RedisResponse) in
-                if  let nestedResponses = self.baseAsserts(response: response, count: 6)  {
+                if  let nestedResponses = self.baseAsserts(response: response, count: 7)  {
                     XCTAssertEqual(nestedResponses[0], RedisResponse.Status("OK"), "mset didn't return an 'OK'")
                     XCTAssertEqual(nestedResponses[1], RedisResponse.Status("OK"), "Failed to rename \(self.key1) to \(self.key3)")
                     XCTAssertEqual(nestedResponses[2], RedisResponse.StringValue(RedisString(self.expVal1)), "\(self.key3) should have been equal to \(self.expVal1). Was \(nestedResponses[2].asString?.asString)")
                     XCTAssertEqual(nestedResponses[3], RedisResponse.IntegerValue(0), "Shouldn't have renamed \(self.key3) to \(self.key2)")
                     XCTAssertEqual(nestedResponses[4], RedisResponse.IntegerValue(1), "Should have renamed \(self.key3) to \(self.key4)")
-                    XCTAssertEqual(nestedResponses[5], RedisResponse.IntegerValue(2), "Only two keys are suppose to exist, reported \(nestedResponses[5].asInteger)")
+                    XCTAssertEqual(nestedResponses[5], RedisResponse.IntegerValue(0), "\(self.key1) shouldn't exist")
+                    XCTAssertEqual(nestedResponses[6], RedisResponse.IntegerValue(1), "\(self.key4) should exist")
                 }
             }
         }


### PR DESCRIPTION
Fixes for issue IBM-Swift/Kitura#623
## Description

Changes to make tests compatible with Redis 2.8.0
## Motivation and Context

Travis-CI containers were downgraded to Ubuntu 14.04, which now pulls Redis 2.8.
## How Has This Been Tested?

Ran tests.
## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have submitted a [CLA form](https://github.com/IBM-Swift/CLA)
- [ ] If applicable, I have updated the documentation accordingly.
- [ ] If applicable, I have added tests to cover my changes.
