### PR TITLE
Added extra unit tests

### DIFF
--- a/Tests/SwiftRedisTests/TestConnectCommands.swift
+++ b/Tests/SwiftRedisTests/TestConnectCommands.swift
@@ -22,10 +22,47 @@ import XCTest
 public class TestConnectCommands: XCTestCase {
     static var allTests: [(String, (TestConnectCommands) -> () throws -> Void)] {
         return [
+            ("test_connectFailure", test_connectFailure),
             ("test_info", test_info),
             ("test_pingAndEcho", test_pingAndEcho),
             ("test_select", test_select)
         ]
+    }
+    
+    func test_connectFailure() {
+        let expectation1 = expectation(description: "Tests a connection failure to a redis server")
+        
+        let failingRedis = Redis()
+        failingRedis.connect(host: "localhostx", port: 6379) {(error: NSError?) in
+            XCTAssertNotNil(error, "Connected to Redis when it shouldn't have")
+            expectation1.fulfill()
+        }
+        waitForExpectations(timeout: 5, handler: {error in XCTAssertNil(error, "Timeout") })
+    }
+    
+    func test_info() {
+        let expectation1 = expectation(description: "Shows some information about the redis server")
+        
+        connectRedis() {(error: NSError?) in
+            if error != nil {
+                XCTFail("Could not connect to Redis")
+                return
+            }
+            
+            redis.info() {
+                (info: RedisInfo?, error: NSError?) in
+                
+                XCTAssertNil(error)
+                XCTAssertNotNil(info)
+                
+                if let theInfo = info {
+                    print("The Redis server version is \(theInfo.server.redis_version)")
+                }
+                
+                expectation1.fulfill()
+            }
+        }
+        waitForExpectations(timeout: 5, handler: {error in XCTAssertNil(error, "Timeout") })
     }
 
     func test_pingAndEcho() {
@@ -110,25 +147,5 @@ public class TestConnectCommands: XCTestCase {
                 }
             }
         }
-    }
-
-    func test_info() {
-        let expectation1 = expectation(description: "Shows some information about the redis server")
-
-        connectRedis() {(error: NSError?) in
-            if error != nil {
-                XCTFail("Could not connect to Redis")
-                return
-            }
-
-            redis.info() {
-                (info: RedisInfo?, error: NSError?) in
-
-                XCTAssertNil(error)
-                XCTAssertNotNil(info)
-                expectation1.fulfill()
-            }
-        }
-        waitForExpectations(timeout: 5, handler: {error in XCTAssertNil(error, "Timeout") })
     }
 }

--- a/Tests/SwiftRedisTests/TestConnectCommands.swift
+++ b/Tests/SwiftRedisTests/TestConnectCommands.swift
@@ -75,18 +75,17 @@ public class TestConnectCommands: XCTestCase {
             redis.ping() {(error: NSError?) in
                 XCTAssertNil(error, "\(error != nil ? error!.localizedDescription : "")")
 
-                /* Changed for Redis 2.8.0
                 let pingText = "Hello, hello, hello, hi there"
                 redis.ping(pingText) {(error: NSError?) in
                     XCTAssertNil(error, "\(error != nil ? error!.localizedDescription : "")")
-                */
+                
                     let echoText = "Echo, echo, echo......"
                     redis.echo(echoText) {(text: RedisString?, error: NSError?) in
                         XCTAssertNil(error, "\(error != nil ? error!.localizedDescription : "")")
                         XCTAssertNotNil(text, "Received a nil for echo text")
                         XCTAssertEqual(text!.asString, echoText, "Echo returned '\(text!)'. Should have returned '\(echoText)'.")
                     }
-               /* } */
+                }
             }
         }
     }

--- a/Tests/SwiftRedisTests/TestConnectCommands.swift
+++ b/Tests/SwiftRedisTests/TestConnectCommands.swift
@@ -59,7 +59,13 @@ public class TestConnectCommands: XCTestCase {
                     print("The Redis server version is \(theInfo.server.redis_version)")
                 }
                 
-                expectation1.fulfill()
+                redis.info() {(info: RedisString?, error: NSError?) in
+                    
+                    XCTAssertNil(error)
+                    XCTAssertNotNil(info)
+                
+                    expectation1.fulfill()
+                }
             }
         }
         waitForExpectations(timeout: 5, handler: {error in XCTAssertNil(error, "Timeout") })


### PR DESCRIPTION
## Description

Added extra tests for various APIs and error conditions that weren't tested. I also enabled some tests that were commented out due to Redis server version issues in the past. Lastly the Redis.info test now writes out the server version to the log.
## Motivation and Context

Improve our test coverage
## How Has This Been Tested?

Ran swift test on both Linux and macOS.
## Checklist:
- [ ] I have submitted a [CLA form](https://github.com/IBM-Swift/CLA)
- [ ] If applicable, I have updated the documentation accordingly.
- [x] If applicable, I have added tests to cover my changes.
