### PR TITLE
Fix String interpolation warnings for 3.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # KituraRedis
 
 [![Build Status](https://travis-ci.org/IBM-Swift/Kitura-redis.svg?branch=master)](https://travis-ci.org/IBM-Swift/Kitura-redis)
-[![Build Status](https://travis-ci.org/IBM-Swift/Kitura-redis.svg?branch=develop)](https://travis-ci.org/IBM-Swift/Kitura-redis)
 
 ***Swift Redis library***
 

--- a/Sources/Redis.swift
+++ b/Sources/Redis.swift
@@ -98,7 +98,7 @@ public class Redis {
                 if  pingStr != nil  &&  pingStr! == str.asString {
                     callback(nil)
                 } else {
-                    callback(self.createError("String result other than '\(pingStr)' received from Redis (\(str))", code: 2))
+                    callback(self.createError("String result other than '\(String(describing: pingStr))' received from Redis (\(str))", code: 2))
                 }
             case .Error(let error):
                 callback(self.createError("Error: \(error)", code: 1))

--- a/Tests/SwiftRedisTests/TestBinarySafeCommands.swift
+++ b/Tests/SwiftRedisTests/TestBinarySafeCommands.swift
@@ -168,7 +168,7 @@ public class TestBinarySafeCommands: XCTestCase {
 
                 redis.get(self.key1) {(value: RedisString?, error: NSError?) in
                     XCTAssertNil(error, "\(error != nil ? error!.localizedDescription : "")")
-                    XCTAssertEqual(value!.asData, expVal1, "\(self.key1) wasn't set to \(expVal1). Instead was \(value)")
+                    XCTAssertEqual(value!.asData, expVal1, "\(self.key1) wasn't set to \(expVal1). Instead was \(String(describing: value))")
 
                     redis.mget(self.key1, self.key2, self.key4, self.key3) {(values: [RedisString?]?, error: NSError?) in
                         XCTAssertNil(error, "\(error != nil ? error!.localizedDescription : "")")
@@ -178,7 +178,7 @@ public class TestBinarySafeCommands: XCTestCase {
                         XCTAssertEqual(values![0]?.asData, expVal1, "Values array [0] wasn't equal to \(expVal1), was \(values![0]!)")
                         XCTAssertNotNil(values![1], "Values array [1] was nil")
                         XCTAssertEqual(values![1]?.asData, expVal2, "Values array [1] wasn't equal to \(expVal2), was \(values![1]!)")
-                        XCTAssertNil(values![2], "Values array [2] wasn't nil. Was \(values![2])")
+                        XCTAssertNil(values![2], "Values array [2] wasn't nil. Was \(String(describing: values![2]))")
                         XCTAssertNotNil(values![3], "Values array [3] was nil")
                         XCTAssertEqual(values![3]?.asData, expVal3, "Values array [3] wasn't equal to \(expVal3), was \(values![3]!)")
 

--- a/Tests/SwiftRedisTests/TestConnectCommands.swift
+++ b/Tests/SwiftRedisTests/TestConnectCommands.swift
@@ -132,7 +132,7 @@ public class TestConnectCommands: XCTestCase {
 
                         redis.get(self.key) {(returnedValue: RedisString?, error: NSError?) in
                             XCTAssertNil(error, "\(error != nil ? error!.localizedDescription : "")")
-                            XCTAssertNil(returnedValue, "Returned value was not nil. Was '\(returnedValue)'")
+                            XCTAssertNil(returnedValue, "Returned value was not nil. Was '\(String(describing: returnedValue))'")
 
                             redis.set(self.key, value: newValue) {(wasSet: Bool, error: NSError?) in
                                 XCTAssertNil(error, "\(error != nil ? error!.localizedDescription : "")")

--- a/Tests/SwiftRedisTests/TestHashCommands.swift
+++ b/Tests/SwiftRedisTests/TestHashCommands.swift
@@ -148,7 +148,7 @@ public class TestHashCommands: XCTestCase {
 
                 redis.hget(self.key1, field: self.field1) {(value: RedisString?, error: NSError?) in
                     XCTAssertNil(error, "\(error != nil ? error!.localizedDescription : "")")
-                    XCTAssertEqual(value!.asString, expVal1, "\(self.key1).\(self.field1) wasn't set to \(expVal1). Instead was \(value)")
+                    XCTAssertEqual(value!.asString, expVal1, "\(self.key1).\(self.field1) wasn't set to \(expVal1). Instead was \(String(describing: value))")
 
                     redis.hmget(self.key1, fields: self.field1, self.field2, self.field4, self.field3) {(values: [RedisString?]?, error: NSError?) in
                         XCTAssertNil(error, "\(error != nil ? error!.localizedDescription : "")")
@@ -158,7 +158,7 @@ public class TestHashCommands: XCTestCase {
                         XCTAssertEqual(values![0]!.asString, expVal1, "Values array [0] wasn't equal to \(expVal1), was \(values![0]!)")
                         XCTAssertNotNil(values![1], "Values array [1] was nil")
                         XCTAssertEqual(values![1]!.asString, expVal2, "Values array [1] wasn't equal to \(expVal2), was \(values![1]!)")
-                        XCTAssertNil(values![2], "Values array [2] wasn't nil. Was \(values![2])")
+                        XCTAssertNil(values![2], "Values array [2] wasn't nil. Was \(String(describing: values![2]))")
                         XCTAssertNotNil(values![3], "Values array [3] was nil")
                         XCTAssertEqual(values![3]!.asString, expVal3, "Values array [3] wasn't equal to \(expVal3), was \(values![3]!)")
 
@@ -181,7 +181,7 @@ public class TestHashCommands: XCTestCase {
                                     for idx in 0..<fieldNames.count {
                                         let field = values[fieldNames[idx]]
                                         XCTAssertNotNil(field, "\(fieldNames[idx]) in \(self.key1) was nil")
-                                        XCTAssertEqual(field!.asString, fieldValues[idx], "\(fieldNames[idx]) in \(self.key1) wasn't '\(fieldValues[idx])', it was \(field)")
+                                        XCTAssertEqual(field!.asString, fieldValues[idx], "\(fieldNames[idx]) in \(self.key1) wasn't '\(fieldValues[idx])', it was \(String(describing: field))")
                                     }
                                 }
                             }
@@ -219,7 +219,7 @@ public class TestHashCommands: XCTestCase {
                         for idx in 0..<fieldNames.count {
                             let field = values[fieldNames[idx]]
                             XCTAssertNotNil(field, "\(fieldNames[idx]) in \(self.key1) was nil")
-                            XCTAssertEqual(field!.asData, fieldValues[idx], "\(fieldNames[idx]) in \(self.key1) wasn't '\(fieldValues[idx])', it was \(field)")
+                            XCTAssertEqual(field!.asData, fieldValues[idx], "\(fieldNames[idx]) in \(self.key1) wasn't '\(fieldValues[idx])', it was \(String(describing: field))")
                         }
                     }
                 }

--- a/Tests/SwiftRedisTests/TestListsPart1.swift
+++ b/Tests/SwiftRedisTests/TestListsPart1.swift
@@ -68,7 +68,7 @@ public class TestListsPart1: XCTestCase {
                 redis.lpop(self.key1) {(popedValue: RedisString?, error: NSError?) in
                     XCTAssertNil(error, "\(error != nil ? error!.localizedDescription : "")")
                     XCTAssertNotNil(popedValue, "Result of lpop was nil, but \(self.key1) should exist")
-                    XCTAssertEqual(popedValue!, RedisString(value2), "Popped \(popedValue) for \(self.key1) instead of \(value2)")
+                    XCTAssertEqual(popedValue!, RedisString(value2), "Popped \(String(describing: popedValue)) for \(self.key1) instead of \(value2)")
 
                     redis.lpushx(self.key1, value: value3) {(numberSet: Int?, error: NSError?) in
                         XCTAssertNil(error, "\(error != nil ? error!.localizedDescription : "")")
@@ -105,7 +105,7 @@ public class TestListsPart1: XCTestCase {
                 redis.lpop(self.key2) {(popedValue: RedisString?, error: NSError?) in
                     XCTAssertNil(error, "\(error != nil ? error!.localizedDescription : "")")
                     XCTAssertNotNil(popedValue, "Result of lpop was nil, but \(self.key2) should exist")
-                    XCTAssertEqual(popedValue!, binaryValue1, "Popped \(popedValue) for \(self.key2) instead of \(binaryValue1)")
+                    XCTAssertEqual(popedValue!, binaryValue1, "Popped \(String(describing: popedValue)) for \(self.key2) instead of \(binaryValue1)")
 
                     redis.lpushx(self.key2, value: binaryValue3) {(numberSet: Int?, error: NSError?) in
                         XCTAssertNil(error, "\(error != nil ? error!.localizedDescription : "")")
@@ -142,7 +142,7 @@ public class TestListsPart1: XCTestCase {
                 redis.rpop(self.key1) {(popedValue: RedisString?, error: NSError?) in
                     XCTAssertNil(error, "\(error != nil ? error!.localizedDescription : "")")
                     XCTAssertNotNil(popedValue, "Result of rpop was nil, but \(self.key1) should exist")
-                    XCTAssertEqual(popedValue!, RedisString(value2), "Popped \(popedValue) for \(self.key1) instead of \(value2)")
+                    XCTAssertEqual(popedValue!, RedisString(value2), "Popped \(String(describing: popedValue)) for \(self.key1) instead of \(value2)")
 
                     redis.rpushx(self.key1, value: value3) {(numberSet: Int?, error: NSError?) in
                         XCTAssertNil(error, "\(error != nil ? error!.localizedDescription : "")")
@@ -179,7 +179,7 @@ public class TestListsPart1: XCTestCase {
                 redis.rpop(self.key2) {(popedValue: RedisString?, error: NSError?) in
                     XCTAssertNil(error, "\(error != nil ? error!.localizedDescription : "")")
                     XCTAssertNotNil(popedValue, "Result of rpop was nil, but \(self.key2) should exist")
-                    XCTAssertEqual(popedValue!, binaryValue1, "Popped \(popedValue) for \(self.key2) instead of \(binaryValue1)")
+                    XCTAssertEqual(popedValue!, binaryValue1, "Popped \(String(describing: popedValue)) for \(self.key2) instead of \(binaryValue1)")
 
                     redis.rpushx(self.key2, value: binaryValue3) {(numberSet: Int?, error: NSError?) in
                         XCTAssertNil(error, "\(error != nil ? error!.localizedDescription : "")")
@@ -220,8 +220,8 @@ public class TestListsPart1: XCTestCase {
                     XCTAssertNil(error, "\(error != nil ? error!.localizedDescription : "")")
                     XCTAssertNotNil(returnedValues, "Result of lrange was nil, without an error")
                     XCTAssertEqual(returnedValues!.count, 2, "Number of values returned by lrange was \(returnedValues!.count) should have been 2")
-                    XCTAssertEqual(returnedValues![0], RedisString(value3), "Returned value #1 was \(returnedValues![0]) should have been \(value3)")
-                    XCTAssertEqual(returnedValues![1], RedisString(value2), "Returned value #2 was \(returnedValues![1]) should have been \(value2)")
+                    XCTAssertEqual(returnedValues![0], RedisString(value3), "Returned value #1 was \(String(describing: returnedValues![0])) should have been \(value3)")
+                    XCTAssertEqual(returnedValues![1], RedisString(value2), "Returned value #2 was \(String(describing: returnedValues![1])) should have been \(value2)")
 
                     redis.lrem(self.key1, count: 3, value: value3) {(removedValues: Int?, error: NSError?) in
                         XCTAssertNil(error, "\(error != nil ? error!.localizedDescription : "")")
@@ -235,8 +235,8 @@ public class TestListsPart1: XCTestCase {
                                 XCTAssertNil(error, "\(error != nil ? error!.localizedDescription : "")")
                                 XCTAssertNotNil(returnedValues, "Result of lrange was nil, without an error")
                                 XCTAssertEqual(returnedValues!.count, 2, "Number of values returned by lrange was \(returnedValues!.count) should have been 2")
-                                XCTAssertEqual(returnedValues![0], binaryValue2, "Returned value #1 was \(returnedValues![0]) should have been \(binaryValue2)")
-                                XCTAssertEqual(returnedValues![1], binaryValue3, "Returned value #2 was \(returnedValues![1]) should have been \(binaryValue3)")
+                                XCTAssertEqual(returnedValues![0], binaryValue2, "Returned value #1 was \(String(describing: returnedValues![0])) should have been \(binaryValue2)")
+                                XCTAssertEqual(returnedValues![1], binaryValue3, "Returned value #2 was \(String(describing: returnedValues![1])) should have been \(binaryValue3)")
 
                                 redis.lrem(self.key1, count: 3, value: binaryValue2) {(removedValues: Int?, error: NSError?) in
                                     XCTAssertNil(error, "\(error != nil ? error!.localizedDescription : "")")

--- a/Tests/SwiftRedisTests/TestListsPart3.swift
+++ b/Tests/SwiftRedisTests/TestListsPart3.swift
@@ -79,15 +79,15 @@ public class TestListsPart3: XCTestCase {
         localSetup() {
             redis.blpop(self.key1, self.key2, timeout: 4.0) {(retrievedValue: [RedisString?]?, error: NSError?) in
                 XCTAssertNil(error, "\(error != nil ? error!.localizedDescription : "")")
-                XCTAssertNil(retrievedValue, "A blpop that timed out should have returned nil. It returned \(retrievedValue)")
+                XCTAssertNil(retrievedValue, "A blpop that timed out should have returned nil. It returned \(String(describing: retrievedValue))")
 
                 redis.brpop(self.key3, self.key1, timeout: 5.0) {(retrievedValue: [RedisString?]?, error: NSError?) in
                     XCTAssertNil(error, "\(error != nil ? error!.localizedDescription : "")")
-                    XCTAssertNil(retrievedValue, "A brpop that timed out should have returned nil. It returned \(retrievedValue)")
+                    XCTAssertNil(retrievedValue, "A brpop that timed out should have returned nil. It returned \(String(describing: retrievedValue))")
 
                     redis.brpoplpush(self.key2, destination: self.key2, timeout: 3.0) {(retrievedValue: RedisString?, error: NSError?) in
                         XCTAssertNil(error, "\(error != nil ? error!.localizedDescription : "")")
-                        XCTAssertNil(retrievedValue, "A brpoplpush that timed out should have returned nil. It returned \(retrievedValue)")
+                        XCTAssertNil(retrievedValue, "A brpoplpush that timed out should have returned nil. It returned \(String(describing: retrievedValue))")
                     }
                 }
             }
@@ -110,8 +110,8 @@ public class TestListsPart3: XCTestCase {
                 XCTAssertNil(error, "\(error != nil ? error!.localizedDescription : "")")
                 XCTAssertNotNil(retrievedValue, "blpop should not have returned nil.")
                 XCTAssertEqual(retrievedValue!.count, 2, "blpop should have returned an array of two elements. It returned an array of \(retrievedValue!.count) elements")
-                XCTAssertEqual(retrievedValue![0], RedisString(self.key2), "blpop's return value element #0 should have been \(self.key2). It was \(retrievedValue![0])")
-                XCTAssertEqual(retrievedValue![1], RedisString(value1), "blpop's return value element #1 should have been \(value1). It was \(retrievedValue![1])")
+                XCTAssertEqual(retrievedValue![0], RedisString(self.key2), "blpop's return value element #0 should have been \(self.key2). It was \(String(describing: retrievedValue![0]))")
+                XCTAssertEqual(retrievedValue![1], RedisString(value1), "blpop's return value element #1 should have been \(value1). It was \(String(describing: retrievedValue![1]))")
             }
         }
     }
@@ -131,8 +131,8 @@ public class TestListsPart3: XCTestCase {
                 XCTAssertNil(error, "\(error != nil ? error!.localizedDescription : "")")
                 XCTAssertNotNil(retrievedValue, "brpop should not have returned nil.")
                 XCTAssertEqual(retrievedValue!.count, 2, "brpop should have returned an array of two elements. It returned an array of \(retrievedValue!.count) elements")
-                XCTAssertEqual(retrievedValue![0], RedisString(self.key3), "brpop's return value element #0 should have been \(self.key3). It was \(retrievedValue![0])")
-                XCTAssertEqual(retrievedValue![1], RedisString(value2), "brpop's return value element #1 should have been \(value2). It was \(retrievedValue![1])")
+                XCTAssertEqual(retrievedValue![0], RedisString(self.key3), "brpop's return value element #0 should have been \(self.key3). It was \(String(describing: retrievedValue![0]))")
+                XCTAssertEqual(retrievedValue![1], RedisString(value2), "brpop's return value element #1 should have been \(value2). It was \(String(describing: retrievedValue![1]))")
             }
         }
     }

--- a/Tests/SwiftRedisTests/TestMoreCommands.swift
+++ b/Tests/SwiftRedisTests/TestMoreCommands.swift
@@ -49,7 +49,7 @@ public class TestMoreCommands: XCTestCase {
 
                 redis.get(self.key1) {(value: RedisString?, error: NSError?) in
                     XCTAssertNil(error, "\(error != nil ? error!.localizedDescription : "")")
-                    XCTAssertEqual(value!.asString, self.expVal1, "\(self.key1) wasn't set to \(self.expVal1). Instead was \(value)")
+                    XCTAssertEqual(value!.asString, self.expVal1, "\(self.key1) wasn't set to \(self.expVal1). Instead was \(String(describing: value))")
 
                     redis.mget(self.key1, self.key2, self.key4, self.key3) {(values: [RedisString?]?, error: NSError?) in
                         XCTAssertNil(error, "\(error != nil ? error!.localizedDescription : "")")
@@ -59,7 +59,7 @@ public class TestMoreCommands: XCTestCase {
                         XCTAssertEqual(values![0]!.asString, self.expVal1, "Values array [0] wasn't equal to \(self.expVal1), was \(values![0]!)")
                         XCTAssertNotNil(values![1], "Values array [1] was nil")
                         XCTAssertEqual(values![1]!.asString, self.expVal2, "Values array [1] wasn't equal to \(self.expVal2), was \(values![1]!)")
-                        XCTAssertNil(values![2], "Values array [2] wasn't nil. Was \(values![2])")
+                        XCTAssertNil(values![2], "Values array [2] wasn't nil. Was \(String(describing: values![2]))")
                         XCTAssertNotNil(values![3], "Values array [3] was nil")
                         XCTAssertEqual(values![3]!.asString, self.expVal3, "Values array [3] wasn't equal to \(self.expVal3), was \(values![3]!)")
 
@@ -94,7 +94,7 @@ public class TestMoreCommands: XCTestCase {
                     redis.get(self.key3) {(value: RedisString?, error: NSError?) in
                         XCTAssertNil(error, "\(error != nil ? error!.localizedDescription : "")")
                         XCTAssertNotNil(value, "\(self.key3) should have been found")
-                        XCTAssertEqual(value!.asString, self.expVal1, "\(self.key3) should have been equal to \(self.expVal1). Was \(value)")
+                        XCTAssertEqual(value!.asString, self.expVal1, "\(self.key3) should have been equal to \(self.expVal1). Was \(String(describing: value))")
 
                         redis.rename(self.key3, newKey: self.key2, exists: false) {(renamed: Bool, error: NSError?) in
                             XCTAssertNil(error, "\(error != nil ? error!.localizedDescription : "")")

--- a/Tests/SwiftRedisTests/TestSetCommands.swift
+++ b/Tests/SwiftRedisTests/TestSetCommands.swift
@@ -77,13 +77,13 @@ public class TestSetCommands: XCTestCase {
 
                     XCTAssertNil(zRangeError)
 
-                    XCTAssertEqual(resultList?[0], RedisString("one"), "The first element of the list should be \(RedisString("one")). It was \(resultList?[0])")
+                    XCTAssertEqual(resultList?[0], RedisString("one"), "The first element of the list should be \(RedisString("one")). It was \(String(describing: resultList?[0]))")
 
-                    XCTAssertEqual(resultList?[1], RedisString("two"), "The first element of the list should be \(RedisString("two")). It was \(resultList?[1])")
+                    XCTAssertEqual(resultList?[1], RedisString("two"), "The first element of the list should be \(RedisString("two")). It was \(String(describing: resultList?[1]))")
 
-                    XCTAssertEqual(resultList?[2], RedisString("three"), "The first element of the list should be \(RedisString("three")). It was \(resultList?[2])")
+                    XCTAssertEqual(resultList?[2], RedisString("three"), "The first element of the list should be \(RedisString("three")). It was \(String(describing: resultList?[2]))")
 
-                    XCTAssertEqual(resultList?.count, 3, "The size of the list should be 3. It was \(resultList?.count)")
+                    XCTAssertEqual(resultList?.count, 3, "The size of the list should be 3. It was \(String(describing: resultList?.count))")
                     expectation1.fulfill()
                 })
 
@@ -106,7 +106,7 @@ public class TestSetCommands: XCTestCase {
                     (retrievedTotalElements: Int?, zCardError: NSError?) in
 
                     XCTAssertNil(zCardError)
-                    XCTAssertEqual(retrievedTotalElements, 3, "The cardinality of the sorted set should be 3. It was \(retrievedTotalElements)")
+                    XCTAssertEqual(retrievedTotalElements, 3, "The cardinality of the sorted set should be 3. It was \(String(describing: retrievedTotalElements))")
                     expectation1.fulfill()
                 })
             }
@@ -129,7 +129,7 @@ public class TestSetCommands: XCTestCase {
 
                     XCTAssertNil(error)
                     XCTAssertNotNil(totalElements)
-                    XCTAssertEqual(totalElements, 3, "The number of items should be 3, there were \(totalElements)")
+                    XCTAssertEqual(totalElements, 3, "The number of items should be 3, there were \(String(describing: totalElements))")
 
                     expectation1.fulfill()
                 })
@@ -153,7 +153,7 @@ public class TestSetCommands: XCTestCase {
 
                     XCTAssertNil(error)
                     XCTAssertNotNil(newScore)
-                    XCTAssertEqual(newScore, RedisString("4"), "New score should be 3 but is \(newScore)")
+                    XCTAssertEqual(newScore, RedisString("4"), "New score should be 3 but is \(String(describing: newScore))")
 
                     expectation1.fulfill()
                 })
@@ -233,7 +233,7 @@ public class TestSetCommands: XCTestCase {
                     (resultList: [RedisString?]?, zRangeError: NSError?) in
 
                     XCTAssertNil(zRangeError)
-                    XCTAssertEqual(resultList?.count, 1, "The number of element(s) return from the specific range should be 1. It was \(resultList?.count)")
+                    XCTAssertEqual(resultList?.count, 1, "The number of element(s) return from the specific range should be 1. It was \(String(describing: resultList?.count))")
                     expectation1.fulfill()
 
                 })
@@ -331,7 +331,7 @@ public class TestSetCommands: XCTestCase {
 
                     XCTAssertNil(error)
                     XCTAssertNotNil(memberRank)
-                    XCTAssertEqual(memberRank, 2, "The rank should be 2, it was \(memberRank)")
+                    XCTAssertEqual(memberRank, 2, "The rank should be 2, it was \(String(describing: memberRank))")
 
                     redis.zrank(self.key1, member: "four", callback: {
                         (memberRank: Int?, error: NSError?) in
@@ -361,7 +361,7 @@ public class TestSetCommands: XCTestCase {
                     (totalElementRem: Int?, zRemError: NSError?) in
 
                     XCTAssertNil(zRemError)
-                    XCTAssertEqual(totalElementRem, 2, "The number of items deleted in the set should be 2. It was \(totalElementRem)")
+                    XCTAssertEqual(totalElementRem, 2, "The number of items deleted in the set should be 2. It was \(String(describing: totalElementRem))")
                     expectation1.fulfill()
                 })
             }
@@ -680,7 +680,7 @@ public class TestSetCommands: XCTestCase {
                     (retrievedTotalElements: Int?, zCardError: NSError?) in
 
                     XCTAssertNil(zCardError)
-                    XCTAssertEqual(retrievedTotalElements, 0, "The cardinality of the sorted set should be 0. It was \(retrievedTotalElements)")
+                    XCTAssertEqual(retrievedTotalElements, 0, "The cardinality of the sorted set should be 0. It was \(String(describing: retrievedTotalElements))")
                 })
             }
             expectation1.fulfill()

--- a/Tests/SwiftRedisTests/TestSetCommandsPart2.swift
+++ b/Tests/SwiftRedisTests/TestSetCommandsPart2.swift
@@ -621,12 +621,12 @@ public class TestSetCommandsPart2: XCTestCase {
                         redis.scard(self.key1) {
                             (retrievedTotalMembers: Int?, error: NSError?) in
                             XCTAssertNil(error)
-                            XCTAssertEqual(retrievedTotalMembers, 1, "There should be 1 member but there are \(retrievedTotalMembers) member(s)")
+                            XCTAssertEqual(retrievedTotalMembers, 1, "There should be 1 member but there are \(String(describing: retrievedTotalMembers)) member(s)")
 
                                 redis.scard(self.key2) {
                                 (retrievedTotalMembers: Int?, error: NSError?) in
                                 XCTAssertNil(error)
-                                XCTAssertEqual(retrievedTotalMembers, 2, "There should be 2 members but there are \(retrievedTotalMembers) member(s)")
+                                XCTAssertEqual(retrievedTotalMembers, 2, "There should be 2 members but there are \(String(describing: retrievedTotalMembers)) member(s)")
 
                                 expectation1.fulfill()
                             }
@@ -664,12 +664,12 @@ public class TestSetCommandsPart2: XCTestCase {
                         redis.scard(self.redisKey1) {
                             (retrievedTotalMembers: Int?, error: NSError?) in
                             XCTAssertNil(error)
-                            XCTAssertEqual(retrievedTotalMembers, 1, "There should be 1 member but there are \(retrievedTotalMembers) member(s)")
+                            XCTAssertEqual(retrievedTotalMembers, 1, "There should be 1 member but there are \(String(describing: retrievedTotalMembers)) member(s)")
 
                                 redis.scard(self.redisKey2) {
                                 (retrievedTotalMembers: Int?, error: NSError?) in
                                 XCTAssertNil(error)
-                                XCTAssertEqual(retrievedTotalMembers, 2, "There should be 2 members but there are \(retrievedTotalMembers) member(s)")
+                                XCTAssertEqual(retrievedTotalMembers, 2, "There should be 2 members but there are \(String(describing: retrievedTotalMembers)) member(s)")
 
                                 expectation1.fulfill()
                             }
@@ -692,13 +692,13 @@ public class TestSetCommandsPart2: XCTestCase {
                     redis.spop(self.key1) {
                     (memberPopped: RedisString?, error: NSError?) in
 
-                    XCTAssertNil(error, "Error: \(error)")
+                    XCTAssertNil(error, "Error: \(String(describing: error))")
                     XCTAssertNotNil(memberPopped)
 
                     redis.scard(self.key1) {
                         (retrievedTotalMembers: Int?, error: NSError?) in
                         XCTAssertNil(error)
-                        XCTAssertEqual(retrievedTotalMembers, 2, "There should be 2 members but there are \(retrievedTotalMembers) member(s)")
+                        XCTAssertEqual(retrievedTotalMembers, 2, "There should be 2 members but there are \(String(describing: retrievedTotalMembers)) member(s)")
 
                             redis.info() {
                             (info: RedisInfo?, error: NSError?) in
@@ -714,13 +714,13 @@ public class TestSetCommandsPart2: XCTestCase {
                                             redis.spop(self.key2, count: 2) {
                                             (memberPopped: [RedisString?]?, error: NSError?) in
 
-                                            XCTAssertNil(error, "Error: \(error)")
+                                            XCTAssertNil(error, "Error: \(String(describing: error))")
                                             XCTAssertNotNil(memberPopped)
 
                                             redis.scard(self.key2) {
                                                 (retrievedTotalMembers: Int?, error: NSError?) in
                                                 XCTAssertNil(error)
-                                                XCTAssertEqual(retrievedTotalMembers, 1, "There should be 1 member but there are \(retrievedTotalMembers) member(s)")
+                                                XCTAssertEqual(retrievedTotalMembers, 1, "There should be 1 member but there are \(String(describing: retrievedTotalMembers)) member(s)")
 
                                                 expectation1.fulfill()
                                             }
@@ -756,7 +756,7 @@ public class TestSetCommandsPart2: XCTestCase {
                     redis.scard(self.redisKey1) {
                         (retrievedTotalMembers: Int?, error: NSError?) in
                         XCTAssertNil(error)
-                        XCTAssertEqual(retrievedTotalMembers, 2, "There should be 2 members but there are \(retrievedTotalMembers) member(s)")
+                        XCTAssertEqual(retrievedTotalMembers, 2, "There should be 2 members but there are \(String(describing: retrievedTotalMembers)) member(s)")
 
                             redis.info() {
                             (info: RedisInfo?, error: NSError?) in
@@ -779,7 +779,7 @@ public class TestSetCommandsPart2: XCTestCase {
                                             redis.scard(self.redisKey2) {
                                                 (retrievedTotalMembers: Int?, error: NSError?) in
                                                 XCTAssertNil(error)
-                                                XCTAssertEqual(retrievedTotalMembers, 1, "There should be 1 member but there are \(retrievedTotalMembers) member(s)")
+                                                XCTAssertEqual(retrievedTotalMembers, 1, "There should be 1 member but there are \(String(describing: retrievedTotalMembers)) member(s)")
 
                                                 expectation1.fulfill()
                                             }

--- a/Tests/SwiftRedisTests/TestStringAndBitCommands.swift
+++ b/Tests/SwiftRedisTests/TestStringAndBitCommands.swift
@@ -95,17 +95,17 @@ public class TestStringAndBitCommands: XCTestCase {
                             redis.bitpos(self.key1, bit: true) {(position: Int?, error: NSError?) in
                                 XCTAssertNil(error, "\(error != nil ? error!.localizedDescription : "")")
                                 XCTAssertNotNil(position, "Position result shouldn't be nil")
-                                XCTAssertEqual(position!, 15, "Bit position should have been 15, was \(position)")
+                                XCTAssertEqual(position!, 15, "Bit position should have been 15, was \(String(describing: position))")
 
                                 redis.bitpos(self.key1, bit: true, start: 2) {(position: Int?, error: NSError?) in
                                     XCTAssertNil(error, "\(error != nil ? error!.localizedDescription : "")")
                                     XCTAssertNotNil(position, "Position result shouldn't be nil")
-                                    XCTAssertEqual(position!, 23, "Bit position should have been 23, was \(position)")
+                                    XCTAssertEqual(position!, 23, "Bit position should have been 23, was \(String(describing: position))")
 
                                     redis.bitpos(self.key1, bit: true, start: 1, end: 2) {(position: Int?, error: NSError?) in
                                         XCTAssertNil(error, "\(error != nil ? error!.localizedDescription : "")")
                                         XCTAssertNotNil(position, "Position result shouldn't be nil")
-                                        XCTAssertEqual(position!, 15, "Bit position should have been 15, was \(position)")
+                                        XCTAssertEqual(position!, 15, "Bit position should have been 15, was \(String(describing: position))")
                                     }
                                 }
                             }
@@ -116,12 +116,12 @@ public class TestStringAndBitCommands: XCTestCase {
                             redis.bitcount(self.key1) {(count: Int?, error: NSError?) in
                                 XCTAssertNil(error, "\(error != nil ? error!.localizedDescription : "")")
                                 XCTAssertNotNil(count, "Count result shouldn't be nil")
-                                XCTAssertEqual(count!, 2, "Bit count should have been 2, was \(count)")
+                                XCTAssertEqual(count!, 2, "Bit count should have been 2, was \(String(describing: count))")
 
                                 redis.bitcount(self.key1, start: 2, end: 2) {(count: Int?, error: NSError?) in
                                     XCTAssertNil(error, "\(error != nil ? error!.localizedDescription : "")")
                                     XCTAssertNotNil(count, "Count result shouldn't be nil")
-                                    XCTAssertEqual(count!, 1, "Bit count should have been 1, was \(count)")
+                                    XCTAssertEqual(count!, 1, "Bit count should have been 1, was \(String(describing: count))")
                                 }
                             }
                      /*   }
@@ -151,7 +151,7 @@ public class TestStringAndBitCommands: XCTestCase {
 
                         redis.get(self.key1) {(value: RedisString?, error: NSError?) in
                             XCTAssertNil(error, "\(error != nil ? error!.localizedDescription : "")")
-                            XCTAssertEqual(value!.asData, newVal1, "The updated bit string had a value of '\(value)'")
+                            XCTAssertEqual(value!.asData, newVal1, "The updated bit string had a value of '\(String(describing: value))'")
                         }
                     }
                 }
@@ -172,7 +172,7 @@ public class TestStringAndBitCommands: XCTestCase {
                 redis.bitop(self.key3, and: self.key1, self.key2) {(length: Int?, error: NSError?) in
                     XCTAssertNil(error, "\(error != nil ? error!.localizedDescription : "")")
                     XCTAssertNotNil(length, "Length result shouldn't be nil")
-                    XCTAssertEqual(length!, 4, "Destination field length should have been 4, was \(length)")
+                    XCTAssertEqual(length!, 4, "Destination field length should have been 4, was \(String(describing: length))")
 
                     redis.get(self.key3) {(value: RedisString?, error: NSError?) in
                         bytes = [0x00, 0x00, 0x00, 0x04]
@@ -180,12 +180,12 @@ public class TestStringAndBitCommands: XCTestCase {
 
                         XCTAssertNil(error, "\(error != nil ? error!.localizedDescription : "")")
                         XCTAssertNotNil(value, "Value result shouldn't be nil")
-                        XCTAssertEqual(value!.asData, newValue, "\(self.key3) after an and had a value of '\(value)'")
+                        XCTAssertEqual(value!.asData, newValue, "\(self.key3) after an and had a value of '\(String(describing: value))'")
 
                         redis.bitop(self.key3, or: self.key1, self.key2) {(length: Int?, error: NSError?) in
                             XCTAssertNil(error, "\(error != nil ? error!.localizedDescription : "")")
                             XCTAssertNotNil(length, "Length result shouldn't be nil")
-                            XCTAssertEqual(length!, 4, "Destination field length should have been 4, was \(length)")
+                            XCTAssertEqual(length!, 4, "Destination field length should have been 4, was \(String(describing: length))")
 
                             redis.get(self.key3) {(value: RedisString?, error: NSError?) in
                                 bytes = [0x00, 0x09, 0x09, 0x04]
@@ -193,12 +193,12 @@ public class TestStringAndBitCommands: XCTestCase {
 
                                 XCTAssertNil(error, "\(error != nil ? error!.localizedDescription : "")")
                                 XCTAssertNotNil(value, "Value result shouldn't be nil")
-                                XCTAssertEqual(value!.asData, newValue, "\(self.key3) after an or had a value of '\(value)'")
+                                XCTAssertEqual(value!.asData, newValue, "\(self.key3) after an or had a value of '\(String(describing: value))'")
 
                                 redis.bitop(self.key3, xor: self.key1, self.key2) {(length: Int?, error: NSError?) in
                                     XCTAssertNil(error, "\(error != nil ? error!.localizedDescription : "")")
                                     XCTAssertNotNil(length, "Length result shouldn't be nil")
-                                    XCTAssertEqual(length!, 4, "Destination field length should have been 4, was \(length)")
+                                    XCTAssertEqual(length!, 4, "Destination field length should have been 4, was \(String(describing: length))")
 
                                     redis.get(self.key3) {(value: RedisString?, error: NSError?) in
                                         bytes = [0x00, 0x09, 0x09, 0x00]
@@ -206,12 +206,12 @@ public class TestStringAndBitCommands: XCTestCase {
 
                                         XCTAssertNil(error, "\(error != nil ? error!.localizedDescription : "")")
                                         XCTAssertNotNil(value, "Value result shouldn't be nil")
-                                        XCTAssertEqual(value!.asData, newValue, "\(self.key3) after a xor had a value of '\(value)'")
+                                        XCTAssertEqual(value!.asData, newValue, "\(self.key3) after a xor had a value of '\(String(describing: value))'")
 
                                         redis.bitop(self.key3, not: self.key1) {(length: Int?, error: NSError?) in
                                             XCTAssertNil(error, "\(error != nil ? error!.localizedDescription : "")")
                                             XCTAssertNotNil(length, "Length result shouldn't be nil")
-                                            XCTAssertEqual(length!, 4, "Destination field length should have been 4, was \(length)")
+                                            XCTAssertEqual(length!, 4, "Destination field length should have been 4, was \(String(describing: length))")
 
                                             redis.get(self.key3) {(value: RedisString?, error: NSError?) in
                                                 bytes = [0xff, 0xfe, 0xfe, 0xfb]
@@ -219,7 +219,7 @@ public class TestStringAndBitCommands: XCTestCase {
 
                                                 XCTAssertNil(error, "\(error != nil ? error!.localizedDescription : "")")
                                                 XCTAssertNotNil(value, "Value result shouldn't be nil")
-                                                XCTAssertEqual(value!.asData, newValue, "\(self.key3) after a not had a value of '\(value)'")
+                                                XCTAssertEqual(value!.asData, newValue, "\(self.key3) after a not had a value of '\(String(describing: value))'")
                                             }
                                         }
                                     }

--- a/Tests/SwiftRedisTests/TestTransactionsPart2.swift
+++ b/Tests/SwiftRedisTests/TestTransactionsPart2.swift
@@ -118,7 +118,7 @@ public class TestTransactionsPart2: XCTestCase {
                     XCTAssertEqual(nestedResponses[3], RedisResponse.StringValue(RedisString(", 1 2")), "Get of getrange wasn't ', 1 2' was \(nestedResponses[3])")
                     XCTAssertEqual(nestedResponses[4], RedisResponse.IntegerValue(updatedLength), "Length of updated \(self.key1) is incorrect")
                     let updatedValue = "Testing, 5 4 3A testing we go, a testing we go"
-                    XCTAssertEqual(nestedResponses[5], RedisResponse.StringValue(RedisString(updatedValue)), "Value of updated \(self.key1) isn't '\(updatedValue), returned \(nestedResponses[5].asString?.asString)")
+                    XCTAssertEqual(nestedResponses[5], RedisResponse.StringValue(RedisString(updatedValue)), "Value of updated \(self.key1) isn't '\(updatedValue), returned \(String(describing: nestedResponses[5].asString?.asString))")
                 }
             }
         }
@@ -139,8 +139,8 @@ public class TestTransactionsPart2: XCTestCase {
             multi.exec() {(response: RedisResponse) in
                 if  let nestedResponses = self.baseAsserts(response: response, count: 3) {
                     XCTAssertEqual(nestedResponses[0], RedisResponse.Status("OK"), "set didn't return an 'OK'")
-                    XCTAssertEqual(nestedResponses[1], RedisResponse.IntegerValue(2), "Bit count should have been 2, was \(nestedResponses[4].asInteger)")
-                    XCTAssertEqual(nestedResponses[2], RedisResponse.IntegerValue(1), "Bit count should have been 1, was \(nestedResponses[5].asInteger)")
+                    XCTAssertEqual(nestedResponses[1], RedisResponse.IntegerValue(2), "Bit count should have been 2, was \(String(describing: nestedResponses[4].asInteger))")
+                    XCTAssertEqual(nestedResponses[2], RedisResponse.IntegerValue(1), "Bit count should have been 1, was \(String(describing: nestedResponses[5].asInteger))")
                     /* Removed tests of bitpos - not in Redis 2.8.0
                     XCTAssertEqual(nestedResponses[3], RedisResponse.IntegerValue(15), "Bit position should have been 15, was \(nestedResponses[1].asInteger)")
                     XCTAssertEqual(nestedResponses[4], RedisResponse.IntegerValue(23), "Bit position should have been 23, was \(nestedResponses[1].asInteger)")
@@ -162,12 +162,12 @@ public class TestTransactionsPart2: XCTestCase {
             multi.exec() {(response: RedisResponse) in
                 if  let nestedResponses = self.baseAsserts(response: response, count: 4) {
                     XCTAssertEqual(nestedResponses[0], RedisResponse.Status("OK"), "set didn't return an 'OK'")
-                    XCTAssertEqual(nestedResponses[1], RedisResponse.IntegerValue(0), "The bit should have been a 0, it was \(nestedResponses[1].asInteger)")
-                    XCTAssertEqual(nestedResponses[2], RedisResponse.IntegerValue(0), "The bit should have been a 0, it was \(nestedResponses[2].asInteger)")
+                    XCTAssertEqual(nestedResponses[1], RedisResponse.IntegerValue(0), "The bit should have been a 0, it was \(String(describing: nestedResponses[1].asInteger))")
+                    XCTAssertEqual(nestedResponses[2], RedisResponse.IntegerValue(0), "The bit should have been a 0, it was \(String(describing: nestedResponses[2].asInteger))")
 
                     bytes = [0x00, 0x05, 0x01, 0x00]
                     let newVal1 = Data(bytes: bytes, count: bytes.count)
-                    XCTAssertEqual(nestedResponses[3].asString?.asData, newVal1, "The updated bit string had a value of '\(nestedResponses[3].asString?.asData)'")
+                    XCTAssertEqual(nestedResponses[3].asString?.asData, newVal1, "The updated bit string had a value of '\(String(describing: nestedResponses[3].asString?.asData))'")
                 }
             }
         }
@@ -190,22 +190,22 @@ public class TestTransactionsPart2: XCTestCase {
             multi.exec() {(response: RedisResponse) in
                 if  let nestedResponses = self.baseAsserts(response: response, count: 9) {
                     XCTAssertEqual(nestedResponses[0], RedisResponse.Status("OK"), "mset didn't return an 'OK'")
-                    XCTAssertEqual(nestedResponses[1], RedisResponse.IntegerValue(4), "Destination field length should have been 4, it was \(nestedResponses[1].asInteger)")
+                    XCTAssertEqual(nestedResponses[1], RedisResponse.IntegerValue(4), "Destination field length should have been 4, it was \(String(describing: nestedResponses[1].asInteger))")
                     bytes = [0x00, 0x00, 0x00, 0x04]
                     var newValue = Data(bytes: bytes, count: bytes.count)
-                    XCTAssertEqual(nestedResponses[2].asString?.asData, newValue, "\(self.key3) after an and had a value of '\(nestedResponses[2].asString?.asData)'")
-                    XCTAssertEqual(nestedResponses[3], RedisResponse.IntegerValue(4), "Destination field length should have been 4, it was \(nestedResponses[3].asInteger)")
+                    XCTAssertEqual(nestedResponses[2].asString?.asData, newValue, "\(self.key3) after an and had a value of '\(String(describing: nestedResponses[2].asString?.asData))'")
+                    XCTAssertEqual(nestedResponses[3], RedisResponse.IntegerValue(4), "Destination field length should have been 4, it was \(String(describing: nestedResponses[3].asInteger))")
                     bytes = [0x00, 0x09, 0x09, 0x04]
                     newValue = Data(bytes: bytes, count: bytes.count)
-                    XCTAssertEqual(nestedResponses[4].asString?.asData, newValue, "\(self.key3) after an or had a value of '\(nestedResponses[4].asString?.asData)'")
-                    XCTAssertEqual(nestedResponses[5], RedisResponse.IntegerValue(4), "Destination field length should have been 4, it was \(nestedResponses[5].asInteger)")
+                    XCTAssertEqual(nestedResponses[4].asString?.asData, newValue, "\(self.key3) after an or had a value of '\(String(describing: nestedResponses[4].asString?.asData))'")
+                    XCTAssertEqual(nestedResponses[5], RedisResponse.IntegerValue(4), "Destination field length should have been 4, it was \(String(describing: nestedResponses[5].asInteger))")
                     bytes = [0x00, 0x09, 0x09, 0x00]
                     newValue = Data(bytes: bytes, count: bytes.count)
-                    XCTAssertEqual(nestedResponses[6].asString?.asData, newValue, "\(self.key3) after an xor had a value of '\(nestedResponses[6].asString?.asData)'")
-                    XCTAssertEqual(nestedResponses[7], RedisResponse.IntegerValue(4), "Destination field length should have been 4, it was \(nestedResponses[7].asInteger)")
+                    XCTAssertEqual(nestedResponses[6].asString?.asData, newValue, "\(self.key3) after an xor had a value of '\(String(describing: nestedResponses[6].asString?.asData))'")
+                    XCTAssertEqual(nestedResponses[7], RedisResponse.IntegerValue(4), "Destination field length should have been 4, it was \(String(describing: nestedResponses[7].asInteger))")
                     bytes = [0xff, 0xfe, 0xfe, 0xfb]
                     newValue = Data(bytes: bytes, count: bytes.count)
-                    XCTAssertEqual(nestedResponses[8].asString?.asData, newValue, "\(self.key3) after a not had a value of '\(nestedResponses[8].asString?.asData)'")
+                    XCTAssertEqual(nestedResponses[8].asString?.asData, newValue, "\(self.key3) after a not had a value of '\(String(describing: nestedResponses[8].asString?.asData))'")
                 }
             }
         }

--- a/Tests/SwiftRedisTests/TestTransactionsPart3.swift
+++ b/Tests/SwiftRedisTests/TestTransactionsPart3.swift
@@ -53,7 +53,7 @@ public class TestTransactionsPart3: XCTestCase {
                 if  let nestedResponses = self.baseAsserts(response: response, count: 7) {
                     XCTAssertEqual(nestedResponses[0], RedisResponse.Status("OK"), "mset didn't return an 'OK'")
                     XCTAssertEqual(nestedResponses[1], RedisResponse.Status("OK"), "Failed to rename \(self.key1) to \(self.key3)")
-                    XCTAssertEqual(nestedResponses[2], RedisResponse.StringValue(RedisString(self.expVal1)), "\(self.key3) should have been equal to \(self.expVal1). Was \(nestedResponses[2].asString?.asString)")
+                    XCTAssertEqual(nestedResponses[2], RedisResponse.StringValue(RedisString(self.expVal1)), "\(self.key3) should have been equal to \(self.expVal1). Was \(String(describing: nestedResponses[2].asString?.asString))")
                     XCTAssertEqual(nestedResponses[3], RedisResponse.IntegerValue(0), "Shouldn't have renamed \(self.key3) to \(self.key2)")
                     XCTAssertEqual(nestedResponses[4], RedisResponse.IntegerValue(1), "Should have renamed \(self.key3) to \(self.key4)")
                     XCTAssertEqual(nestedResponses[5], RedisResponse.IntegerValue(0), "\(self.key1) shouldn't exist")
@@ -75,7 +75,7 @@ public class TestTransactionsPart3: XCTestCase {
                     XCTAssertEqual(nestedResponses[2], RedisResponse.IntegerValue(1), "Should have moved \(self.key1) to DB 0")
                     XCTAssertEqual(nestedResponses[3], RedisResponse.Nil, "\(self.key1) should no longer exist in DB 1")
                     XCTAssertEqual(nestedResponses[4], RedisResponse.Status("OK"), "Select(0) didn't return an 'OK'")
-                    XCTAssertEqual(nestedResponses[5], RedisResponse.StringValue(RedisString(self.expVal1)), "\(self.key1) should have been equal to \(self.expVal1). Was \(nestedResponses[5].asString?.asString)")
+                    XCTAssertEqual(nestedResponses[5], RedisResponse.StringValue(RedisString(self.expVal1)), "\(self.key1) should have been equal to \(self.expVal1). Was \(String(describing: nestedResponses[5].asString?.asString))")
                 }
             }
         }
@@ -95,7 +95,7 @@ public class TestTransactionsPart3: XCTestCase {
             multi.exec() {(response: RedisResponse) in
                 if  let nestedResponses = self.baseAsserts(response: response, count: 7) {
                     XCTAssertEqual(nestedResponses[0], RedisResponse.Status("OK"), "set didn't return an 'OK'")
-                    XCTAssertEqual(nestedResponses[1], RedisResponse.IntegerValue(-1), "\(self.key1) shouldn't have an expiration. It has \(nestedResponses[1].asInteger)")
+                    XCTAssertEqual(nestedResponses[1], RedisResponse.IntegerValue(-1), "\(self.key1) shouldn't have an expiration. It has \(String(describing: nestedResponses[1].asInteger))")
                     XCTAssertEqual(nestedResponses[2], RedisResponse.IntegerValue(1), "Expiration for \(self.key1) wasn't set")
                     var intResponse = nestedResponses[3].asInteger
                     XCTAssertNotNil(intResponse, "ttl for \(self.key1) was nil")

--- a/Tests/SwiftRedisTests/TestTransactionsPart4.swift
+++ b/Tests/SwiftRedisTests/TestTransactionsPart4.swift
@@ -53,7 +53,7 @@ public class TestTransactionsPart4: XCTestCase {
                 if  let nestedResponses = self.baseAsserts(response: response, count: 10) {
                     XCTAssertEqual(nestedResponses[0], RedisResponse.IntegerValue(1), "\(self.field1) wasn't a new field in \(self.key1)")
                     XCTAssertEqual(nestedResponses[1], RedisResponse.IntegerValue(0), "\(self.field1) wasn't an existing field in \(self.key1)")
-                    XCTAssertEqual(nestedResponses[2], RedisResponse.StringValue(RedisString(expVal2)), "\(self.key1) should have been equal to \(expVal2). Was \(nestedResponses[2].asString?.asString)")
+                    XCTAssertEqual(nestedResponses[2], RedisResponse.StringValue(RedisString(expVal2)), "\(self.key1) should have been equal to \(expVal2). Was \(String(describing: nestedResponses[2].asString?.asString))")
                     XCTAssertEqual(nestedResponses[3], RedisResponse.IntegerValue(0), "\(self.field2) isn't suppose to exist in \(self.key1)")
                     XCTAssertEqual(nestedResponses[4], RedisResponse.IntegerValue(1), "\(self.field2) wasn't a new field in \(self.key1)")
                     XCTAssertEqual(nestedResponses[5], RedisResponse.IntegerValue(2), "There should be two fields in \(self.key1)")
@@ -82,8 +82,8 @@ public class TestTransactionsPart4: XCTestCase {
 
             multi.exec() {(response: RedisResponse) in
                 if  let nestedResponses = self.baseAsserts(response: response, count: 2  /* Should be 4 if testing hstrlen */ ) {
-                    XCTAssertEqual(nestedResponses[0], RedisResponse.IntegerValue(Int64(incInt)), "Value of the field should be \(incInt), was \(nestedResponses[0].asInteger)")
-                    XCTAssertEqual(nestedResponses[1], RedisResponse.StringValue(RedisString(String(incFloat))), "Value of the field should be \(incFloat). Was \(nestedResponses[1].asString?.asString)")
+                    XCTAssertEqual(nestedResponses[0], RedisResponse.IntegerValue(Int64(incInt)), "Value of the field should be \(incInt), was \(String(describing: nestedResponses[0].asInteger))")
+                    XCTAssertEqual(nestedResponses[1], RedisResponse.StringValue(RedisString(String(incFloat))), "Value of the field should be \(incFloat). Was \(String(describing: nestedResponses[1].asString?.asString))")
 
                     // To test HSTRLEN one needs a Redis 3.2 server
                     //
@@ -109,7 +109,7 @@ public class TestTransactionsPart4: XCTestCase {
             multi.exec() {(response: RedisResponse) in
                 if  let nestedResponses = self.baseAsserts(response: response, count: 6) {
                     XCTAssertEqual(nestedResponses[0], RedisResponse.Status("OK"), "Fields 1,2,3 should have been set")
-                    XCTAssertEqual(nestedResponses[1], RedisResponse.StringValue(RedisString(expVal1)), "\(self.key1).\(self.field1) wasn't set to \(expVal1). Was \(nestedResponses[1].asString?.asString)")
+                    XCTAssertEqual(nestedResponses[1], RedisResponse.StringValue(RedisString(expVal1)), "\(self.key1).\(self.field1) wasn't set to \(expVal1). Was \(String(describing: nestedResponses[1].asString?.asString))")
                     let innerResponses = nestedResponses[2].asArray!
                     XCTAssertEqual(innerResponses.count, 4, "Values array didn't have four elements. Had \(innerResponses.count) elements")
                     XCTAssertEqual(innerResponses[0].asString!.asString, expVal1, "Values array [0] wasn't equal to \(expVal1), was \(innerResponses[0].asString!.asString)")
@@ -147,7 +147,7 @@ public class TestTransactionsPart4: XCTestCase {
                     let valuesMap = [self.field1:expData1, self.field2:expData2, self.field3:expData3]
                     for idx in stride(from: 0, to: innerResponses.count-1, by:2) {
                         XCTAssertNotNil(valuesMap[innerResponses[idx].asString!.asString], "Unknown field \(innerResponses[idx].asString!.asString)")
-                        XCTAssertEqual(valuesMap[innerResponses[idx].asString!.asString], innerResponses[idx+1].asString!.asData, "Value of \(innerResponses[idx].asString!.asData) wasn't '\(valuesMap[innerResponses[idx].asString!.asString])'. It was '\(innerResponses[idx+1].asString!.asData)'")
+                        XCTAssertEqual(valuesMap[innerResponses[idx].asString!.asString], innerResponses[idx+1].asString!.asData, "Value of \(innerResponses[idx].asString!.asData) wasn't '\(String(describing: valuesMap[innerResponses[idx].asString!.asString]))'. It was '\(innerResponses[idx+1].asString!.asData)'")
                     }
                 }
             }

--- a/Tests/SwiftRedisTests/TestTransactionsPart7.swift
+++ b/Tests/SwiftRedisTests/TestTransactionsPart7.swift
@@ -111,7 +111,7 @@ public class TestTransactionsPart7: XCTestCase {
                     
                     // lpop(self.key1)
                     XCTAssertNotNil(response2, "Result of lpop was nil, but \(self.key1) should exist")
-                    XCTAssertEqual(response2, RedisString(value2), "Popped \(response2) for \(self.key1) instead of \(value2)")
+                    XCTAssertEqual(response2, RedisString(value2), "Popped \(String(describing: response2)) for \(self.key1) instead of \(value2)")
                     
                     // lpushx(self.key1, value: value3)
                     XCTAssertNotNil(response3, "Result of lpushx was nil, without an error")
@@ -122,7 +122,7 @@ public class TestTransactionsPart7: XCTestCase {
                     
                     // lpushx(self.key3, value: value3)
                     XCTAssertNotNil(response5, "Result of lpushx was nil, without an error")
-                    XCTAssertEqual(response5, 0, "lpushx to \(self.key3) should have returned 0 (list not found) returned \(response5)")
+                    XCTAssertEqual(response5, 0, "lpushx to \(self.key3) should have returned 0 (list not found) returned \(String(describing: response5))")
                 }
             }
         }
@@ -156,7 +156,7 @@ public class TestTransactionsPart7: XCTestCase {
                     
                     // lpop(self.key1)
                     XCTAssertNotNil(response2, "Result of lpop was nil, but \(self.key1) should exist")
-                    XCTAssertEqual(response2, value2, "Popped \(response2) for \(self.key1) instead of \(value2)")
+                    XCTAssertEqual(response2, value2, "Popped \(String(describing: response2)) for \(self.key1) instead of \(value2)")
                     
                     // lpushx(self.key1, value: value3)
                     XCTAssertNotNil(response3, "Result of lpushx was nil, without an error")
@@ -167,7 +167,7 @@ public class TestTransactionsPart7: XCTestCase {
                     
                     // lpushx(self.key3, value: value3)
                     XCTAssertNotNil(response5, "Result of lpushx was nil, without an error")
-                    XCTAssertEqual(response5, 0, "lpushx to \(self.key3) should have returned 0 (list not found) returned \(response5)")
+                    XCTAssertEqual(response5, 0, "lpushx to \(self.key3) should have returned 0 (list not found) returned \(String(describing: response5))")
                 }
             }
         }
@@ -201,7 +201,7 @@ public class TestTransactionsPart7: XCTestCase {
                     
                     // rpop(self.key1)
                     XCTAssertNotNil(response2, "Result of rpop was nil, but \(self.key1) should exist")
-                    XCTAssertEqual(response2, RedisString(value2), "Popped \(response2) for \(self.key1) instead of \(value2)")
+                    XCTAssertEqual(response2, RedisString(value2), "Popped \(String(describing: response2)) for \(self.key1) instead of \(value2)")
                     
                     // rpushx(self.key1, value: value3)
                     XCTAssertNotNil(response3, "Result of rpushx was nil, without an error")
@@ -212,7 +212,7 @@ public class TestTransactionsPart7: XCTestCase {
                     
                     // rpushx(self.key3, value: value3)
                     XCTAssertNotNil(response5, "Result of rpushx was nil, without an error")
-                    XCTAssertEqual(response5, 0, "rpushx to \(self.key3) should have returned 0 (list not found) returned \(response5)")
+                    XCTAssertEqual(response5, 0, "rpushx to \(self.key3) should have returned 0 (list not found) returned \(String(describing: response5))")
                 }
             }
         }
@@ -246,7 +246,7 @@ public class TestTransactionsPart7: XCTestCase {
                     
                     // rpop(self.key1)
                     XCTAssertNotNil(response2, "Result of rpop was nil, but \(self.key1) should exist")
-                    XCTAssertEqual(response2, value2, "Popped \(response2) for \(self.key1) instead of \(value2)")
+                    XCTAssertEqual(response2, value2, "Popped \(String(describing: response2)) for \(self.key1) instead of \(value2)")
                     
                     // rpushx(self.key1, value: value3)
                     XCTAssertNotNil(response3, "Result of rpushx was nil, without an error")
@@ -257,7 +257,7 @@ public class TestTransactionsPart7: XCTestCase {
                     
                     // rpushx(self.key3, value: value3)
                     XCTAssertNotNil(response5, "Result of rpushx was nil, without an error")
-                    XCTAssertEqual(response5, 0, "rpushx to \(self.key3) should have returned 0 (list not found) returned \(response5)")
+                    XCTAssertEqual(response5, 0, "rpushx to \(self.key3) should have returned 0 (list not found) returned \(String(describing: response5))")
                 }
             }
         }
@@ -292,23 +292,23 @@ public class TestTransactionsPart7: XCTestCase {
                     
                     // lrange(self.key1, start: 1, end: 2)
                     XCTAssertNotNil(response2, "Result of lrange was nil, without an error")
-                    XCTAssertEqual(response2?.count, 2, "Number of values returned by lrange was \(response2?.count) should have been 2")
-                    XCTAssertEqual(response2?[0].asString, RedisString(value3), "Returned value #1 was \(response2?[0]) should have been \(value3)")
-                    XCTAssertEqual(response2?[1].asString, RedisString(value2), "Returned value #2 was \(response2?[1]) should have been \(value2)")
+                    XCTAssertEqual(response2?.count, 2, "Number of values returned by lrange was \(String(describing: response2?.count)) should have been 2")
+                    XCTAssertEqual(response2?[0].asString, RedisString(value3), "Returned value #1 was \(String(describing: response2?[0])) should have been \(value3)")
+                    XCTAssertEqual(response2?[1].asString, RedisString(value2), "Returned value #2 was \(String(describing: response2?[1])) should have been \(value2)")
                     
                     // lrem(self.key1, count: 3, value: value3)
                     XCTAssertNotNil(response3, "Result of lrem was nil, without an error")
-                    XCTAssertEqual(response3, 1, "Number of values removed by lrem was \(response3) should have been 1")
+                    XCTAssertEqual(response3, 1, "Number of values removed by lrem was \(String(describing: response3)) should have been 1")
                     
                     //(self.key2, values: binaryValue4, binaryValue3, binaryValue2, binaryValue1)
                     XCTAssertNotNil(response5, "Result of lrange was nil, without an error")
-                    XCTAssertEqual(response5?.count, 2, "Number of values returned by lrange was \(response5?.count) should have been 2")
-                    XCTAssertEqual(response5?[0].asString, binaryValue2, "Returned value #1 was \(response5?[0]) should have been \(binaryValue2)")
-                    XCTAssertEqual(response5?[1].asString, binaryValue3, "Returned value #2 was \(response5?[1]) should have been \(binaryValue3)")
+                    XCTAssertEqual(response5?.count, 2, "Number of values returned by lrange was \(String(describing: response5?.count)) should have been 2")
+                    XCTAssertEqual(response5?[0].asString, binaryValue2, "Returned value #1 was \(String(describing: response5?[0])) should have been \(binaryValue2)")
+                    XCTAssertEqual(response5?[1].asString, binaryValue3, "Returned value #2 was \(String(describing: response5?[1])) should have been \(binaryValue3)")
                     
                     // lrem(self.key1, count: 3, value: binaryValue2)
                     XCTAssertNotNil(response6, "Result of lrem was nil, without an error")
-                    XCTAssertEqual(response6, 1, "Number of values removed by lrem was \(response6) should have been 1")
+                    XCTAssertEqual(response6, 1, "Number of values removed by lrem was \(String(describing: response6)) should have been 1")
                 }
             }
         }
@@ -336,15 +336,15 @@ public class TestTransactionsPart7: XCTestCase {
                     
                     // linsert(self.key1, before: true, pivot: value3, value: value2)
                     XCTAssertNotNil(response2, "Result of linsert was nil, but \(self.key1) should exist")
-                    XCTAssertEqual(response2, 3, "Returned \(response2) for \(self.key1) instead of 3")
+                    XCTAssertEqual(response2, 3, "Returned \(String(describing: response2)) for \(self.key1) instead of 3")
                     
                     // llen(self.key1)
                     XCTAssertNotNil(response3, "Result of llen was nil, but \(self.key1) should exist")
-                    XCTAssertEqual(response3, 3, "Returned \(response3) for \(self.key1) instead of 3")
+                    XCTAssertEqual(response3, 3, "Returned \(String(describing: response3)) for \(self.key1) instead of 3")
                     
                     // lindex(self.key1, index: 2)
                     XCTAssertNotNil(response4, "Result of lindex was nil, but \(self.key1) should exist")
-                    XCTAssertEqual(response4, RedisString(value1), "Result of lindex was \(response4). It should have been \(value1)")
+                    XCTAssertEqual(response4, RedisString(value1), "Result of lindex was \(String(describing: response4)). It should have been \(value1)")
                 }
             }
         }
@@ -371,15 +371,15 @@ public class TestTransactionsPart7: XCTestCase {
                     
                     // linsert(self.key1, before: true, pivot: value3, value: value2)
                     XCTAssertNotNil(response2, "Result of linsert was nil, but \(self.key1) should exist")
-                    XCTAssertEqual(response2, 3, "Returned \(response2) for \(self.key1) instead of 3")
+                    XCTAssertEqual(response2, 3, "Returned \(String(describing: response2)) for \(self.key1) instead of 3")
                     
                     // llen(self.key1)
                     XCTAssertNotNil(response3, "Result of llen was nil, but \(self.key1) should exist")
-                    XCTAssertEqual(response3, 3, "Returned \(response3) for \(self.key1) instead of 3")
+                    XCTAssertEqual(response3, 3, "Returned \(String(describing: response3)) for \(self.key1) instead of 3")
                     
                     // lindex(self.key1, index: 2)
                     XCTAssertNotNil(response4, "Result of lindex was nil, but \(self.key1) should exist")
-                    XCTAssertEqual(response4, value1, "Result of lindex was \(response4). It should have been \(value1)")
+                    XCTAssertEqual(response4, value1, "Result of lindex was \(String(describing: response4)). It should have been \(value1)")
                 }
             }
         }
@@ -411,14 +411,14 @@ public class TestTransactionsPart7: XCTestCase {
                     
                     // lindex(self.key1, index: 1)
                     XCTAssertNotNil(response3, "Returned values of lindex was nil, even though no error occurred.")
-                    XCTAssertEqual(response3, RedisString(value2), "lindex returned \(response3). It should have returned \(value2)")
+                    XCTAssertEqual(response3, RedisString(value2), "lindex returned \(String(describing: response3)). It should have returned \(value2)")
                     
                     // ltrim(self.key1, start: 0, end: 0)
                     XCTAssertEqual(response4, "OK", "lset failed")
                     
                     // llen(self.key1)
                     XCTAssertNotNil(response5, "Returned values of llen was nil, even though no error occurred.")
-                    XCTAssertEqual(response5, 1, "The length of the list was \(response5). It should have been 1.")
+                    XCTAssertEqual(response5, 1, "The length of the list was \(String(describing: response5)). It should have been 1.")
                 }
             }
         }
@@ -450,14 +450,14 @@ public class TestTransactionsPart7: XCTestCase {
                     
                     // lindex(self.key1, index: 1)
                     XCTAssertNotNil(response3, "Returned values of lindex was nil, even though no error occurred.")
-                    XCTAssertEqual(response3, value2, "lindex returned \(response3). It should have returned \(value2)")
+                    XCTAssertEqual(response3, value2, "lindex returned \(String(describing: response3)). It should have returned \(value2)")
                     
                     // ltrim(self.key1, start: 0, end: 0)
                     XCTAssertEqual(response4, "OK", "lset failed")
                     
                     // llen(self.key1)
                     XCTAssertNotNil(response5, "Returned values of llen was nil, even though no error occurred.")
-                    XCTAssertEqual(response5, 1, "The length of the list was \(response5). It should have been 1.")
+                    XCTAssertEqual(response5, 1, "The length of the list was \(String(describing: response5)). It should have been 1.")
                 }
             }
         }
@@ -484,15 +484,15 @@ public class TestTransactionsPart7: XCTestCase {
                     
                     // rpoplpush(self.key1, destination: self.key2)
                     XCTAssertNotNil(response2, "Returned values of rpoplpush was nil, even though no error occurred.")
-                    XCTAssertEqual(response2, RedisString(value3), "rpoplpush returned \(response2). It should have returned \(value3)")
+                    XCTAssertEqual(response2, RedisString(value3), "rpoplpush returned \(String(describing: response2)). It should have returned \(value3)")
                     
                     // llen(self.key1)
                     XCTAssertNotNil(response3, "Returned values of llen was nil, even though no error occurred.")
-                    XCTAssertEqual(response3, 2, "The length of the list \(self.key1) was \(response3). It should have been 2.")
+                    XCTAssertEqual(response3, 2, "The length of the list \(self.key1) was \(String(describing: response3)). It should have been 2.")
                     
                     // llen(self.key2)
                     XCTAssertNotNil(response4, "Returned values of llen was nil, even though no error occurred.")
-                    XCTAssertEqual(response4, 1, "The length of the list \(self.key2) was \(response4). It should have been 1.")
+                    XCTAssertEqual(response4, 1, "The length of the list \(self.key2) was \(String(describing: response4)). It should have been 1.")
                 }
             }
         }
@@ -550,9 +550,9 @@ public class TestTransactionsPart7: XCTestCase {
                     
                     // blpop(self.key1, self.key2, self.key3, timeout: 4.0)
                     XCTAssertNotNil(response2, "blpop should not have returned nil.")
-                    XCTAssertEqual(response2?.count, 2, "blpop should have returned an array of two elements. It returned an array of \(response2?.count) elements")
-                    XCTAssertEqual(response2?[0].asString, RedisString(self.key2), "blpop's return value element #0 should have been \(self.key2). It was \(response2?[0])")
-                    XCTAssertEqual(response2?[1].asString, RedisString(value1), "blpop's return value element #1 should have been \(value1). It was \(response2?[1])")
+                    XCTAssertEqual(response2?.count, 2, "blpop should have returned an array of two elements. It returned an array of \(String(describing: response2?.count)) elements")
+                    XCTAssertEqual(response2?[0].asString, RedisString(self.key2), "blpop's return value element #0 should have been \(self.key2). It was \(String(describing: response2?[0]))")
+                    XCTAssertEqual(response2?[1].asString, RedisString(value1), "blpop's return value element #1 should have been \(value1). It was \(String(describing: response2?[1]))")
                 }
             }
         }
@@ -578,9 +578,9 @@ public class TestTransactionsPart7: XCTestCase {
                     
                     // brpop(self.key1, self.key2, self.key3, timeout: 4.0)
                     XCTAssertNotNil(response2, "brpop should not have returned nil.")
-                    XCTAssertEqual(response2?.count, 2, "brpop should have returned an array of two elements. It returned an array of \(response2?.count) elements")
-                    XCTAssertEqual(response2?[0].asString, RedisString(self.key3), "brpop's return value element #0 should have been \(self.key3). It was \(response2?[0])")
-                    XCTAssertEqual(response2?[1].asString, RedisString(value2), "brpop's return value element #1 should have been \(value2). It was \(response2?[1])")
+                    XCTAssertEqual(response2?.count, 2, "brpop should have returned an array of two elements. It returned an array of \(String(describing: response2?.count)) elements")
+                    XCTAssertEqual(response2?[0].asString, RedisString(self.key3), "brpop's return value element #0 should have been \(self.key3). It was \(String(describing: response2?[0]))")
+                    XCTAssertEqual(response2?[1].asString, RedisString(value2), "brpop's return value element #1 should have been \(value2). It was \(String(describing: response2?[1]))")
                 }
             }
         }
@@ -604,11 +604,11 @@ public class TestTransactionsPart7: XCTestCase {
                     
                     // brpoplpush(self.key1, destination: self.key2, timeout: 4.0)
                     XCTAssertNotNil(response2, "brpoplpush should not have returned nil.")
-                    XCTAssertEqual(response2, RedisString(value1), "brpoplpush's return value  should have been \(value1). It was \(response2)")
+                    XCTAssertEqual(response2, RedisString(value1), "brpoplpush's return value  should have been \(value1). It was \(String(describing: response2))")
                     
                     // brpoplpush(self.key1, destination: self.key2, timeout: 4.0)
                     XCTAssertNotNil(response3, "brpoplpush should not have returned nil.")
-                    XCTAssertEqual(response3, RedisString(value2), "brpoplpush's return value  should have been \(value2). It was \(response3)")
+                    XCTAssertEqual(response3, RedisString(value2), "brpoplpush's return value  should have been \(value2). It was \(String(describing: response3))")
                 }
             }
         }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Fix String interpolation warnings for 3.1

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have submitted a [CLA form](https://github.com/IBM-Swift/CLA)
- [ ] If applicable, I have updated the documentation accordingly.
- [ ] If applicable, I have added tests to cover my changes.
