### PR TITLE
Add test for Mac vs Linux test count. Randomize test order on Linux. …

### DIFF
--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -15,33 +15,58 @@
  **/
 
 import XCTest
+import Glibc
 @testable import SwiftRedisTests
 
+// http://stackoverflow.com/questions/24026510/how-do-i-shuffle-an-array-in-swift
+extension MutableCollection where Indices.Iterator.Element == Index {
+    mutating func shuffle() {
+        let c = count
+        guard c > 1 else { return }
+
+        srand(UInt32(time(nil)))
+        for (firstUnshuffled, unshuffledCount) in zip(indices, stride(from: c, to: 1, by: -1)) {
+            let d: IndexDistance = numericCast(random() % numericCast(unshuffledCount))
+            guard d != 0 else { continue }
+            let i = index(firstUnshuffled, offsetBy: d)
+            swap(&self[firstUnshuffled], &self[i])
+        }
+    }
+}
+
+extension Sequence {
+    func shuffled() -> [Iterator.Element] {
+        var result = Array(self)
+        result.shuffle()
+        return result
+    }
+}
+
 XCTMain([
-    testCase(AuthTests.allTests),
-	testCase(TestBasicCommands.allTests),
-	testCase(TestBinarySafeCommands.allTests),
-	testCase(TestBitfield.allTests),
-	testCase(TestConnectCommands.allTests),
-	testCase(TestGeoCommands.allTests),
-	testCase(TestGeoRadius.allTests),
-	testCase(TestGeoRadiusByMember.allTests),
-	testCase(TestHashCommands.allTests),
-	testCase(TestIssueCommand.allTests),
-	testCase(TestListsPart1.allTests),
-	testCase(TestListsPart2.allTests),
-	testCase(TestListsPart3.allTests),
-	testCase(TestMoreCommands.allTests),
-	testCase(TestSetCommands.allTests),
-	testCase(TestSetCommandsPart2.allTests),
-	testCase(TestSort.allTests),
-	testCase(TestStringAndBitCommands.allTests),
-	testCase(TestTransactionsPart1.allTests),
-	testCase(TestTransactionsPart2.allTests),
-	testCase(TestTransactionsPart3.allTests),
-	testCase(TestTransactionsPart4.allTests),
-	testCase(TestTransactionsPart5.allTests),
-	testCase(TestTransactionsPart6.allTests),
-	testCase(TestTransactionsPart7.allTests),
-	testCase(TestTransactionsPart8.allTests)
-])
+    testCase(AuthTests.allTests.shuffled()),
+    testCase(TestBasicCommands.allTests.shuffled()),
+    testCase(TestBinarySafeCommands.allTests.shuffled()),
+    testCase(TestBitfield.allTests.shuffled()),
+    testCase(TestConnectCommands.allTests.shuffled()),
+    testCase(TestGeoCommands.allTests.shuffled()),
+    testCase(TestGeoRadius.allTests.shuffled()),
+    testCase(TestGeoRadiusByMember.allTests.shuffled()),
+    testCase(TestHashCommands.allTests.shuffled()),
+    testCase(TestIssueCommand.allTests.shuffled()),
+    testCase(TestListsPart1.allTests.shuffled()),
+    testCase(TestListsPart2.allTests.shuffled()),
+    testCase(TestListsPart3.allTests.shuffled()),
+    testCase(TestMoreCommands.allTests.shuffled()),
+    testCase(TestSetCommands.allTests.shuffled()),
+    testCase(TestSetCommandsPart2.allTests.shuffled()),
+    testCase(TestSort.allTests.shuffled()),
+    testCase(TestStringAndBitCommands.allTests.shuffled()),
+    testCase(TestTransactionsPart1.allTests.shuffled()),
+    testCase(TestTransactionsPart2.allTests.shuffled()),
+    testCase(TestTransactionsPart3.allTests.shuffled()),
+    testCase(TestTransactionsPart4.allTests.shuffled()),
+    testCase(TestTransactionsPart5.allTests.shuffled()),
+    testCase(TestTransactionsPart6.allTests.shuffled()),
+    testCase(TestTransactionsPart7.allTests.shuffled()),
+    testCase(TestTransactionsPart8.allTests.shuffled())
+    ].shuffled())

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -18,13 +18,14 @@ import XCTest
 import Glibc
 @testable import SwiftRedisTests
 
+srand(UInt32(time(nil)))
+
 // http://stackoverflow.com/questions/24026510/how-do-i-shuffle-an-array-in-swift
 extension MutableCollection where Indices.Iterator.Element == Index {
     mutating func shuffle() {
         let c = count
         guard c > 1 else { return }
 
-        srand(UInt32(time(nil)))
         for (firstUnshuffled, unshuffledCount) in zip(indices, stride(from: c, to: 1, by: -1)) {
             let d: IndexDistance = numericCast(random() % numericCast(unshuffledCount))
             guard d != 0 else { continue }

--- a/Tests/SwiftRedisTests/TestGeoCommands.swift
+++ b/Tests/SwiftRedisTests/TestGeoCommands.swift
@@ -25,6 +25,7 @@ public class TestGeoCommands: XCTestCase {
             ("test_geohash", test_geohash),
             ("test_geopos", test_geopos),
             ("test_geoposNonExisting", test_geoposNonExisting),
+            ("test_geoposMixed", test_geoposMixed),
             ("test_geodist", test_geodist),
             ("test_geodistM", test_geodistM),
             ("test_geodistKM", test_geodistKM),

--- a/Tests/SwiftRedisTests/VerifyLinuxTestCount.swift
+++ b/Tests/SwiftRedisTests/VerifyLinuxTestCount.swift
@@ -1,0 +1,164 @@
+/**
+ * Copyright IBM Corporation 2017
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+#if os(OSX)
+    import XCTest
+
+    class VerifyLinuxTestCount: XCTestCase {
+        var linuxCount: Int = 0
+        var darwinCount: Int = 0
+    }
+
+    // Non-transaction commands
+    extension VerifyLinuxTestCount {
+        func testNonTranscationCommands() {
+            // AuthTests
+            linuxCount = AuthTests.allTests.count
+            darwinCount = Int(AuthTests.defaultTestSuite().testCaseCount)
+            XCTAssertEqual(linuxCount, darwinCount, "\(darwinCount - linuxCount) tests are missing from AuthTests.allTests")
+
+            // TestBasicCommands
+            linuxCount = TestBasicCommands.allTests.count
+            darwinCount = Int(TestBasicCommands.defaultTestSuite().testCaseCount)
+            XCTAssertEqual(linuxCount, darwinCount, "\(darwinCount - linuxCount) tests are missing from TestBasicCommands.allTests")
+
+            // TestBinarySafeCommands
+            linuxCount = TestBinarySafeCommands.allTests.count
+            darwinCount = Int(TestBinarySafeCommands.defaultTestSuite().testCaseCount)
+            XCTAssertEqual(linuxCount, darwinCount, "\(darwinCount - linuxCount) tests are missing from TestBinarySafeCommands.allTests")
+
+            // TestBitfield
+            linuxCount = TestBitfield.allTests.count
+            darwinCount = Int(TestBitfield.defaultTestSuite().testCaseCount)
+            XCTAssertEqual(linuxCount, darwinCount, "\(darwinCount - linuxCount) tests are missing from TestBitfield.allTests")
+
+            // TestConnectCommands
+            linuxCount = TestConnectCommands.allTests.count
+            darwinCount = Int(TestConnectCommands.defaultTestSuite().testCaseCount)
+            XCTAssertEqual(linuxCount, darwinCount, "\(darwinCount - linuxCount) tests are missing from TestConnectCommands.allTests")
+
+            // TestGeoCommands
+            linuxCount = TestGeoCommands.allTests.count
+            darwinCount = Int(TestGeoCommands.defaultTestSuite().testCaseCount)
+            XCTAssertEqual(linuxCount, darwinCount, "\(darwinCount - linuxCount) tests are missing from TestGeoCommands.allTests")
+
+            // TestGeoRadius
+            linuxCount = TestGeoRadius.allTests.count
+            darwinCount = Int(TestGeoRadius.defaultTestSuite().testCaseCount)
+            XCTAssertEqual(linuxCount, darwinCount, "\(darwinCount - linuxCount) tests are missing from TestGeoRadius.allTests")
+
+            // TestGeoRadiusByMember
+            linuxCount = TestGeoRadiusByMember.allTests.count
+            darwinCount = Int(TestGeoRadiusByMember.defaultTestSuite().testCaseCount)
+            XCTAssertEqual(linuxCount, darwinCount, "\(darwinCount - linuxCount) tests are missing from TestGeoRadiusByMember.allTests")
+
+            // TestHashCommands
+            linuxCount = TestHashCommands.allTests.count
+            darwinCount = Int(TestHashCommands.defaultTestSuite().testCaseCount)
+            XCTAssertEqual(linuxCount, darwinCount, "\(darwinCount - linuxCount) tests are missing from TestHashCommands.allTests")
+
+            // TestIssueCommand
+            linuxCount = TestIssueCommand.allTests.count
+            darwinCount = Int(TestIssueCommand.defaultTestSuite().testCaseCount)
+            XCTAssertEqual(linuxCount, darwinCount, "\(darwinCount - linuxCount) tests are missing from TestIssueCommand.allTests")
+
+            // TestListsPart1
+            linuxCount = TestListsPart1.allTests.count
+            darwinCount = Int(TestListsPart1.defaultTestSuite().testCaseCount)
+            XCTAssertEqual(linuxCount, darwinCount, "\(darwinCount - linuxCount) tests are missing from TestListsPart1.allTests")
+
+            // TestListsPart2
+            linuxCount = TestListsPart2.allTests.count
+            darwinCount = Int(TestListsPart2.defaultTestSuite().testCaseCount)
+            XCTAssertEqual(linuxCount, darwinCount, "\(darwinCount - linuxCount) tests are missing from TestListsPart2.allTests")
+
+            // TestListsPart3
+            linuxCount = TestListsPart3.allTests.count
+            darwinCount = Int(TestListsPart3.defaultTestSuite().testCaseCount)
+            XCTAssertEqual(linuxCount, darwinCount, "\(darwinCount - linuxCount) tests are missing from TestListsPart3.allTests")
+
+            // TestMoreCommands
+            linuxCount = TestMoreCommands.allTests.count
+            darwinCount = Int(TestMoreCommands.defaultTestSuite().testCaseCount)
+            XCTAssertEqual(linuxCount, darwinCount, "\(darwinCount - linuxCount) tests are missing from TestMoreCommands.allTests")
+
+            // TestSetCommands
+            linuxCount = TestSetCommands.allTests.count
+            darwinCount = Int(TestSetCommands.defaultTestSuite().testCaseCount)
+            XCTAssertEqual(linuxCount, darwinCount, "\(darwinCount - linuxCount) tests are missing from TestSetCommands.allTests")
+
+            // TestSetCommandsPart2
+            linuxCount = TestSetCommandsPart2.allTests.count
+            darwinCount = Int(TestSetCommandsPart2.defaultTestSuite().testCaseCount)
+            XCTAssertEqual(linuxCount, darwinCount, "\(darwinCount - linuxCount) tests are missing from TestSetCommandsPart2.allTests")
+
+            // TestSort
+            linuxCount = TestSort.allTests.count
+            darwinCount = Int(TestSort.defaultTestSuite().testCaseCount)
+            XCTAssertEqual(linuxCount, darwinCount, "\(darwinCount - linuxCount) tests are missing from TestSort.allTests")
+
+            // TestStringAndBitCommands
+            linuxCount = TestStringAndBitCommands.allTests.count
+            darwinCount = Int(TestStringAndBitCommands.defaultTestSuite().testCaseCount)
+            XCTAssertEqual(linuxCount, darwinCount, "\(darwinCount - linuxCount) tests are missing from TestStringAndBitCommands.allTests")
+        }
+    }
+
+    // Transaction commands
+    extension VerifyLinuxTestCount {
+        func testTransactionCommands() {
+            // TestTransactionsPart1
+            linuxCount = TestTransactionsPart1.allTests.count
+            darwinCount = Int(TestTransactionsPart1.defaultTestSuite().testCaseCount)
+            XCTAssertEqual(linuxCount, darwinCount, "\(darwinCount - linuxCount) tests are missing from TestTransactionsPart1.allTests")
+
+            // TestTransactionsPart2
+            linuxCount = TestTransactionsPart2.allTests.count
+            darwinCount = Int(TestTransactionsPart2.defaultTestSuite().testCaseCount)
+            XCTAssertEqual(linuxCount, darwinCount, "\(darwinCount - linuxCount) tests are missing from TestTransactionsPart2.allTests")
+
+            // TestTransactionsPart3
+            linuxCount = TestTransactionsPart3.allTests.count
+            darwinCount = Int(TestTransactionsPart3.defaultTestSuite().testCaseCount)
+            XCTAssertEqual(linuxCount, darwinCount, "\(darwinCount - linuxCount) tests are missing from TestTransactionsPart3.allTests")
+
+            // TestTransactionsPart4
+            linuxCount = TestTransactionsPart4.allTests.count
+            darwinCount = Int(TestTransactionsPart4.defaultTestSuite().testCaseCount)
+            XCTAssertEqual(linuxCount, darwinCount, "\(darwinCount - linuxCount) tests are missing from TestTransactionsPart4.allTests")
+
+            // TestTransactionsPart5
+            linuxCount = TestTransactionsPart5.allTests.count
+            darwinCount = Int(TestTransactionsPart5.defaultTestSuite().testCaseCount)
+            XCTAssertEqual(linuxCount, darwinCount, "\(darwinCount - linuxCount) tests are missing from TestTransactionsPart5.allTests")
+
+            // TestTransactionsPart6
+            linuxCount = TestTransactionsPart6.allTests.count
+            darwinCount = Int(TestTransactionsPart6.defaultTestSuite().testCaseCount)
+            XCTAssertEqual(linuxCount, darwinCount, "\(darwinCount - linuxCount) tests are missing from TestTransactionsPart6.allTests")
+
+            // TestTransactionsPart7
+            linuxCount = TestTransactionsPart7.allTests.count
+            darwinCount = Int(TestTransactionsPart7.defaultTestSuite().testCaseCount)
+            XCTAssertEqual(linuxCount, darwinCount, "\(darwinCount - linuxCount) tests are missing from TestTransactionsPart7.allTests")
+
+            // TestTransactionsPart8
+            linuxCount = TestTransactionsPart8.allTests.count
+            darwinCount = Int(TestTransactionsPart8.defaultTestSuite().testCaseCount)
+            XCTAssertEqual(linuxCount, darwinCount, "\(darwinCount - linuxCount) tests are missing from TestTransactionsPart8.allTests")
+        }
+    }
+#endif


### PR DESCRIPTION
…IBM-Swift/Kitura#1056

## Description
- Add a test class that checks if every other test class has included all their tests in their `allTests` var (found one missing test)
- Add extensions in `LinuxMain.swift` to shuffle an array, and shuffle the order that the test classes are run, as well as the tests within the classes

## Motivation and Context
[#1056](https://github.com/IBM-Swift/Kitura/issues/1056)

## How Has This Been Tested?
OSX: Swift 3.1
Linux: Swift 3.1 & Swift 3.0.2