### PR TITLE
Make connected computed property

### DIFF
--- a/Sources/Redis.swift
+++ b/Sources/Redis.swift
@@ -25,28 +25,28 @@ public class Redis {
     /// Redis Serialization Protocol handle
     private var respHandle: RedisResp?
     
-    /// Whether the client is connected or not
+    /// Whether the client is connected or not.
+    /// Does not reflect state changes in the event of a disconnect.
     public var connected: Bool {
-        return respHandle != nil ? respHandle?.status == .connected : false
+        return respHandle?.status == .connected
     }
     
     /// Initializes a `Redis` instance
-    public init () { }
+    public init () {}
     
     /// Connects to a redis server
     ///
     /// - Parameter host: the server IP address.
     /// - Parameter port: port number.
     /// - Parameter callback: callback function for on completion, NSError will be nil if successful.
-    public func connect (host: String, port: Int32, callback: (NSError?) -> Void) {
-        
-        var error: NSError? = nil
-        
+    public func connect(host: String, port: Int32, callback: (NSError?) -> Void) {
         respHandle = RedisResp(host: host, port: port)
-        if  respHandle!.status != .connected {
-            error = createError("Failed to connect to Redis server", code: 2)
+
+        if respHandle?.status == .notConnected {
+            callback(createError("Failed to connect to Redis server", code: 2))
+        } else {
+            callback(nil)
         }
-        callback(error)
     }
     
     /// Authenticate against the server


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
`connected` currently only reflects the result of initially trying to connect to the database.

I've made it a computed property that returns whether the underlying socket `isConnected`.

However, this socket property does not get updated in the event of a disconnect (only on `socket.close()`). I've noted this in the documentation.

Also various small code improvements.

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
#56 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
All tests still pass on macOS.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have submitted a [CLA form](https://github.com/IBM-Swift/CLA)
- [ ] If applicable, I have updated the documentation accordingly.
- [ ] If applicable, I have added tests to cover my changes.
