### PR TITLE
Clarify usage comment for set() functions

### DIFF
--- a/Sources/SwiftRedis/Redis+Basic.swift
+++ b/Sources/SwiftRedis/Redis+Basic.swift
@@ -604,7 +604,7 @@ extension Redis {
     ///
     /// - Parameter key: The key.
     /// - Parameter value: The String value to set.
-    /// - Parameter exists: If true will only set the key if it already exists.
+    /// - Parameter exists: If true will only set the key if it already exists. If false will only set the key if it doesn't already exist.
     /// - Parameter expiresIn: If not nil, the expiration time, in milliseconds.
     /// - Parameter callback: The callback function after setting the value. Bool will be
     ///                      true if the key was set. NSError will be non-nil if an error occurred.
@@ -628,7 +628,7 @@ extension Redis {
     ///
     /// - Parameter key: The key.
     /// - Parameter value: The `RedisString` value to set.
-    /// - Parameter exists: If true will only set the key if it already exists.
+    /// - Parameter exists: If true will only set the key if it already exists. If false will only set the key if it doesn't already exist.
     /// - Parameter expiresIn: If not nil, the expiration time, in milliseconds.
     /// - Parameter callback: The callback function after setting the value. Bool will be
     ///                      true if the key was set. NSError will be non-nil if an error occurred.


### PR DESCRIPTION
It was not immediately clear that supplying a value of false for the "exists" argument has a special meaning. It causes the "NX" argument to be sent to Redis, as opposed to no argument when supplying a value of nil. At least that was my experience when using this function for the first time - the implications of true/false/nil were not explained until I read the source code for this function.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have submitted a [CLA form](https://github.com/IBM-Swift/CLA)
- [x] If applicable, I have updated the documentation accordingly.
- [x] If applicable, I have added tests to cover my changes.
